### PR TITLE
 Increasing energy consumption from ship rods

### DIFF
--- a/code/modules/power/fusion_engine.dm
+++ b/code/modules/power/fusion_engine.dm
@@ -82,10 +82,10 @@
 		switch(power_gen_percent) //Flavor text!
 			if(10)
 				balloon_alert_to_viewers("begins to whirr as it powers up")
-				fuel_rate = FUSION_ENGINE_FULL_STRENGTH_FULL_RATE * 0.1
+				fuel_rate = FUSION_ENGINE_FULL_STRENGTH_FULL_RATE * 0.2
 			if(50)
 				balloon_alert_to_viewers("hums as it reaches half capacity")
-				fuel_rate = FUSION_ENGINE_FULL_STRENGTH_FULL_RATE * 0.5
+				fuel_rate = FUSION_ENGINE_FULL_STRENGTH_FULL_RATE * 0.8
 			if(100)
 				balloon_alert_to_viewers("rumbles as it reaches full strength")
 				fuel_rate = FUSION_ENGINE_FULL_STRENGTH_FULL_RATE


### PR DESCRIPTION
## `Основные изменения`
Изменил потребление заряда стержней в генераторах корабля
Если в стержнях меньше 10%, то 0.1 > 0.2
Если в стержнях меньше 50%, то 0.5 > 0.8

## `Как это улучшит игру`
Работа для шиптехов, стержни требуют обслуживания чаще 1 раза за раунд

## `Ченджлог`
:cl:
balance: повышено потребление заряда стержней в генераторах корабля
/:cl: