### PR TITLE
Ports 14878, 15112, 15167

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -208,19 +208,6 @@
 
 #define MAX_PARALYSE_AMOUNT_FOR_PARALYSE_RESISTANT 2 SECONDS
 
-//Xeno Overlays Indexes//////////
-#define X_PRED_LASER_LAYER 10
-#define X_LASER_LAYER 9
-#define X_WOUND_LAYER 8
-#define X_HEAD_LAYER 7
-#define X_SUIT_LAYER 6
-#define X_L_HAND_LAYER 5
-#define X_R_HAND_LAYER 4
-#define X_TARGETED_LAYER 3
-#define X_FIRE_LAYER 1
-#define X_TOTAL_LAYERS 10
-/////////////////////////////////
-
 // No neighbors
 #define NEIGHBORS_NONE  0
 // Cardinal neighborhood

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -407,13 +407,14 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define HUMAN_MAX_PALENESS 30 //this is added to human skin tone to get value of pale_max variable
 
 
-// Human Overlay Indexes
-/* RU TGMC EDIT
-#define LASER_LAYER 29 //For sniper targeting laser
-#define MOTH_WINGS_LAYER 28
-#define MUTATIONS_LAYER 27
-#define DAMAGE_LAYER 26
-RU TGMC EDIT */
+// Overlay Indexes
+#define PRED_LASER_LAYER 32
+#define LASER_LAYER 31
+#define WOUND_LAYER 30
+#define MOTH_WINGS_LAYER 29
+#define MUTATIONS_LAYER 28
+#define DAMAGE_LAYER 27
+#define FLAY_LAYER 26
 #define UNIFORM_LAYER 25
 #define TAIL_LAYER 24 //bs12 specific. this hack is probably gonna come back to haunt me
 #define ID_LAYER 23
@@ -439,9 +440,9 @@ RU TGMC EDIT */
 #define OVERHEALTH_SHIELD_LAYER 3
 #define TARGETED_LAYER 2 //for target sprites when held at gun point, and holo cards.
 #define FIRE_LAYER 1 //If you're on fire
-/* RU TGMC EDIT
-#define TOTAL_LAYERS 29
-RU TGMC EDIT */
+
+#define TOTAL_LAYERS 32
+
 #define MOTH_WINGS_BEHIND_LAYER 1
 
 #define TOTAL_UNDERLAYS 1
@@ -486,7 +487,6 @@ RU TGMC EDIT */
 #define XENO_SLOWDOWN_REGEN 0.4
 
 #define XENO_DEADHUMAN_DRAG_SLOWDOWN 2
-//#define XENO_EXPLOSION_GIB_THRESHOLD 0.95 //if your effective bomb armour is less than 5, devestating explosions will gib xenos //RUTGMC REMOVAL - Explosions
 
 #define KING_SUMMON_TIMER_DURATION 5 MINUTES
 
@@ -595,7 +595,7 @@ RU TGMC EDIT */
 
 #define RAVAGER_ENDURE_DURATION				10 SECONDS
 #define RAVAGER_ENDURE_DURATION_WARNING		0.7
-#define RAVAGER_ENDURE_HP_LIMIT				-125 //RUTGMC EDIT
+#define RAVAGER_ENDURE_HP_LIMIT				-125
 
 #define RAVAGER_RAGE_DURATION							10 SECONDS
 #define RAVAGER_RAGE_WARNING							0.7
@@ -813,8 +813,6 @@ GLOBAL_LIST_INIT(human_body_parts, list(BODY_ZONE_HEAD,
 #define GRAB_PIXEL_SHIFT_NECK 16
 
 #define HUMAN_CARRY_SLOWDOWN 0.35
-//#define HUMAN_EXPLOSION_GIB_THRESHOLD 0.1 //RUTGMC DELETION, explosions
-
 
 // =============================
 // Hallucinations - health hud screws for carbon mobs
@@ -887,14 +885,6 @@ GLOBAL_LIST_INIT(human_body_parts, list(BODY_ZONE_HEAD,
 #define BASE_WALL_SLAM_DAMAGE 15
 ///Default damage for slamming a mob against another mob
 #define BASE_MOB_SLAM_DAMAGE 8
-
-#define MOTH_WINGS_LAYER 28
-#define MUTATIONS_LAYER 27
-#define DAMAGE_LAYER 26
-#define FLAY_LAYER 25
-#define PRED_LASER_LAYER 1.9
-#define LASER_LAYER 1.8
-#define TOTAL_LAYERS 30
 
 // Yautja defines
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -114,7 +114,6 @@
 	return
 
 /mob/living/carbon/xenomorph/med_hud_set_status()
-	hud_set_plasma()
 	hud_set_pheromone()
 
 /mob/living/carbon/human/med_hud_set_status()

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -15,9 +15,7 @@
 	var/fire_alert = FALSE
 	var/pressure_alert = FALSE
 
-//RUTGMC EDIT
 	var/butchery_progress = 0
-//RUTGMC EDIT
 
 	var/list/internal_organs = list()
 	///Overall drunkenness - check handle_status_effects() in life.dm for effects
@@ -48,6 +46,8 @@
 	var/list/datum/action/ability/mob_abilities = list()
 	///Currently selected ability
 	var/datum/action/ability/activable/selected_ability
+	///carbon overlay layers
+	var/list/overlays_standing[TOTAL_LAYERS]
 
 /mob/living/carbon/proc/transfer_identity(mob/living/carbon/destination)
 	if(!istype(destination))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -61,13 +61,9 @@ There are several things that need to be remembered:
 
 #define ITEM_STATE_IF_SET(I) I.item_state ? I.item_state : I.icon_state
 
-
 /mob/living/carbon/human
-	var/list/overlays_standing[TOTAL_LAYERS]
 	var/list/underlays_standing[TOTAL_UNDERLAYS]
 	var/previous_damage_appearance // store what the body last looked like, so we only have to update it if something changed
-
-
 
 /mob/living/carbon/human/apply_overlay(cache_index)
 	var/list/to_add = list()
@@ -677,7 +673,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 /mob/living/carbon/human/update_burst()
 	remove_overlay(BURST_LAYER)
 	var/mutable_appearance/standing
-//RUTGMC EDIT ADDITION BEGIN - Preds
 	if(chestburst == 1)
 		if(isyautja(src))
 			standing = mutable_appearance('icons/Xeno/Effects.dmi', "predburst_stand", -BURST_LAYER)
@@ -688,7 +683,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			standing = mutable_appearance('icons/Xeno/Effects.dmi', "predbursted_stand", -BURST_LAYER)
 		else
 			standing = mutable_appearance('icons/Xeno/Effects.dmi', "bursted_stand", -BURST_LAYER)
-//RUTGMC EDIT ADDITION END
 
 	overlays_standing[BURST_LAYER] = standing
 	apply_overlay(BURST_LAYER)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -119,25 +119,23 @@
 
 /mob/living/carbon/xenomorph/proc/handle_living_plasma_updates()
 	var/turf/T = loc
-	if(!T || !istype(T))
+	if(!istype(T)) //This means plasma doesn't update while you're in things like a vent, but since you don't have weeds in a vent or can actually take advantage of pheros, this is fine
 		return
-	if(plasma_stored >= xeno_caste.plasma_max * xeno_caste.plasma_regen_limit)
+
+	if(!current_aura && (plasma_stored >= xeno_caste.plasma_max * xeno_caste.plasma_regen_limit)) //no loss or gain
 		return
 
 	if(current_aura)
 		if(plasma_stored < pheromone_cost)
-			use_plasma(plasma_stored)
+			use_plasma(plasma_stored, FALSE)
 			QDEL_NULL(current_aura)
 			src.balloon_alert(src, "Stop emitting, no plasma")
 		else
-			use_plasma(pheromone_cost)
+			use_plasma(pheromone_cost, FALSE)
 
-	if(HAS_TRAIT(src, TRAIT_NOPLASMAREGEN))
-		hud_set_plasma()
-		return
-
-	if(!loc_weeds_type && !(xeno_caste.caste_flags & CASTE_INNATE_PLASMA_REGEN))
-		hud_set_plasma() // since we used some plasma via the aura
+	if(HAS_TRAIT(src, TRAIT_NOPLASMAREGEN) || !loc_weeds_type && !(xeno_caste.caste_flags & CASTE_INNATE_PLASMA_REGEN))
+		if(current_aura) //we only need to update if we actually used plasma from pheros
+			hud_set_plasma()
 		return
 
 	var/plasma_gain = xeno_caste.plasma_gain
@@ -152,7 +150,6 @@
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_PLASMA_REGEN, plasma_mod)
 
 	gain_plasma(plasma_mod[1])
-	hud_set_plasma() //update plasma amount on the plasma mob_hud
 
 /mob/living/carbon/xenomorph/can_receive_aura(aura_type, atom/source, datum/aura_bearer/bearer)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -40,7 +40,6 @@
 	update_fire() //the fire overlay depends on the xeno's stance, so we must update it.
 	update_wounds()
 
-	hud_set_plasma()
 	med_hud_set_health()
 	hud_set_sunder()
 	hud_set_firestacks()

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -52,35 +52,35 @@
 	update_icons()
 
 /mob/living/carbon/xenomorph/update_inv_r_hand()
-	remove_overlay(X_R_HAND_LAYER)
+	remove_overlay(R_HAND_LAYER)
 	if(r_hand)
 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
 			r_hand.screen_loc = ui_rhand
 			client.screen += r_hand
 
-		overlays_standing[X_R_HAND_LAYER] = r_hand.make_worn_icon(inhands = TRUE, slot_name = slot_r_hand_str, default_icon = 'icons/mob/items_righthand_1.dmi', default_layer = X_R_HAND_LAYER)
-		apply_overlay(X_R_HAND_LAYER)
+		overlays_standing[R_HAND_LAYER] = r_hand.make_worn_icon(inhands = TRUE, slot_name = slot_r_hand_str, default_icon = 'icons/mob/items_righthand_1.dmi', default_layer = R_HAND_LAYER)
+		apply_overlay(R_HAND_LAYER)
 
 /mob/living/carbon/xenomorph/update_inv_l_hand()
-	remove_overlay(X_L_HAND_LAYER)
+	remove_overlay(L_HAND_LAYER)
 	if(l_hand)
 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
 			l_hand.screen_loc = ui_lhand
 			client.screen += l_hand
 
-		overlays_standing[X_L_HAND_LAYER] = l_hand.make_worn_icon(inhands = TRUE, slot_name = slot_l_hand_str, default_icon = 'icons/mob/items_lefthand_1.dmi', default_layer = X_L_HAND_LAYER)
-		apply_overlay(X_L_HAND_LAYER)
+		overlays_standing[L_HAND_LAYER] = l_hand.make_worn_icon(inhands = TRUE, slot_name = slot_l_hand_str, default_icon = 'icons/mob/items_lefthand_1.dmi', default_layer = L_HAND_LAYER)
+		apply_overlay(L_HAND_LAYER)
 
 /mob/living/carbon/xenomorph/proc/create_shriekwave(color)
 	var/image/shriekwave = image("icon"='icons/Xeno/64x64_Xeno_overlays.dmi', "icon_state" = "shriek_waves") //Ehh, suit layer's not being used.
 	if(color)
 		shriekwave.color = color
-	overlays_standing[X_SUIT_LAYER] = shriekwave
-	apply_temp_overlay(X_SUIT_LAYER, 3 SECONDS)
+	overlays_standing[SUIT_LAYER] = shriekwave
+	apply_temp_overlay(SUIT_LAYER, 3 SECONDS)
 
 /mob/living/carbon/xenomorph/proc/create_stomp()
-	overlays_standing[X_SUIT_LAYER] = image("icon"='icons/Xeno/64x64_Xeno_overlays.dmi', "icon_state" = "stomp") //Ehh, suit layer's not being used.
-	apply_temp_overlay(X_SUIT_LAYER, 1.2 SECONDS)
+	overlays_standing[SUIT_LAYER] = image("icon"='icons/Xeno/64x64_Xeno_overlays.dmi', "icon_state" = "stomp") //Ehh, suit layer's not being used.
+	apply_temp_overlay(SUIT_LAYER, 1.2 SECONDS)
 
 /mob/living/carbon/xenomorph/update_fire()
 	if(!fire_overlay)
@@ -96,7 +96,7 @@
 	if(QDELETED(src))
 		return
 
-	remove_overlay(X_WOUND_LAYER)
+	remove_overlay(WOUND_LAYER)
 	remove_filter("wounded_filter")
 
 	var/health_thresholds
@@ -135,8 +135,8 @@
 	if(xeno_caste.caste_flags & CASTE_HAS_WOUND_MASK)
 		var/image/wounded_mask = image(icon, null, "alpha_[overlay_to_show]")
 		wounded_mask.render_target = "*[REF(src)]"
-		overlays_standing[X_WOUND_LAYER] = wounded_mask
-		apply_overlay(X_WOUND_LAYER)
+		overlays_standing[WOUND_LAYER] = wounded_mask
+		apply_overlay(WOUND_LAYER)
 		add_filter("wounded_filter", 1, alpha_mask_filter(0, 0, null, "*[REF(src)]", MASK_INVERSE))
 
 	wound_overlay.vis_flags &= ~VIS_HIDE // Show the overlay

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -283,7 +283,6 @@ RU TGMC EDIT */
 	///State tracking of hive status toggles
 	var/status_toggle_flags = HIVE_STATUS_DEFAULTS
 
-	var/list/overlays_standing[X_TOTAL_LAYERS]
 	var/atom/movable/vis_obj/xeno_wounds/wound_overlay
 	var/atom/movable/vis_obj/xeno_wounds/fire_overlay/fire_overlay
 	var/datum/xeno_caste/xeno_caste

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -109,7 +109,7 @@
 	maxHealth = xeno_caste.max_health * GLOB.xeno_stat_multiplicator_buff
 	if(restore_health_and_plasma)
 		// xenos that manage plasma through special means shouldn't gain it for free on aging
-		plasma_stored = max(plasma_stored, xeno_caste.plasma_max * xeno_caste.plasma_regen_limit)
+		set_plasma(max(plasma_stored, xeno_caste.plasma_max * xeno_caste.plasma_regen_limit))
 		health = maxHealth
 	setXenoCasteSpeed(xeno_caste.speed)
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -135,6 +135,8 @@
 
 	. += "Sunder: [100-sunder]% armor left"
 
+	. += "Regeneration power: [max(regen_power * 100, 0)]%"
+
 	//Very weak <= 1.0, weak <= 2.0, no modifier 2-3, strong <= 3.5, very strong <= 4.5
 	var/msg_holder = ""
 	if(frenzy_aura)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -191,16 +191,25 @@
 		return FALSE
 	return TRUE
 
-/mob/living/carbon/xenomorph/proc/use_plasma(value)
+/mob/living/carbon/xenomorph/proc/set_plasma(value, update_plasma = TRUE)
+	plasma_stored = clamp(value, 0, xeno_caste.plasma_max)
+	if(!update_plasma)
+		return
+	hud_set_plasma()
+
+/mob/living/carbon/xenomorph/proc/use_plasma(value, update_plasma = TRUE)
 	plasma_stored = max(plasma_stored - value, 0)
 	update_action_button_icons()
+	if(!update_plasma)
+		return
+	hud_set_plasma()
 
-/mob/living/carbon/xenomorph/proc/gain_plasma(value)
+/mob/living/carbon/xenomorph/proc/gain_plasma(value, update_plasma = TRUE)
 	plasma_stored = min(plasma_stored + value, xeno_caste.plasma_max)
 	update_action_button_icons()
-
-
-
+	if(!update_plasma)
+		return
+	hud_set_plasma()
 
 //Strip all inherent xeno verbs from your caste. Used in evolution.
 /mob/living/carbon/xenomorph/proc/remove_inherent_verbs()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -360,7 +360,7 @@
 
 
 /mob/living/carbon/xenomorph/revive(admin_revive = FALSE)
-	plasma_stored = xeno_caste.plasma_max
+	set_plasma(xeno_caste.plasma_max)
 	sunder = 0
 	if(stat == DEAD)
 		hive?.on_xeno_revive(src)

--- a/code/modules/predator/yautja/weapons/ranged.dm
+++ b/code/modules/predator/yautja/weapons/ranged.dm
@@ -461,20 +461,15 @@
 /atom/proc/can_apply_pred_laser()
 	return FALSE
 
-/mob/living/carbon/human/can_apply_pred_laser()
+/mob/living/carbon/can_apply_pred_laser()
 	if(!overlays_standing[PRED_LASER_LAYER])
-		return TRUE
-	return FALSE
-
-/mob/living/carbon/xenomorph/can_apply_pred_laser()
-	if(!overlays_standing[X_PRED_LASER_LAYER])
 		return TRUE
 	return FALSE
 
 /atom/proc/apply_pred_laser()
 	return FALSE
 
-/mob/living/carbon/human/apply_pred_laser()
+/mob/living/carbon/apply_pred_laser()
 	overlays_standing[PRED_LASER_LAYER] = image("icon" = 'icons/mob/hunter/pred_gear.dmi', "icon_state" = "locking-y", "layer" = -PRED_LASER_LAYER)
 	apply_overlay(PRED_LASER_LAYER)
 	spawn(2 SECONDS)
@@ -484,25 +479,11 @@
 			apply_overlay(PRED_LASER_LAYER)
 	return TRUE
 
-/mob/living/carbon/xenomorph/apply_pred_laser()
-	overlays_standing[X_PRED_LASER_LAYER] = image("icon" = 'icons/mob/hunter/pred_gear.dmi', "icon_state" = "locking-y", "layer" = -X_PRED_LASER_LAYER)
-	apply_overlay(X_PRED_LASER_LAYER)
-	spawn(2 SECONDS)
-		if(overlays_standing[X_PRED_LASER_LAYER])
-			remove_overlay(X_PRED_LASER_LAYER)
-			overlays_standing[X_PRED_LASER_LAYER] = image("icon" = 'icons/mob/hunter/pred_gear.dmi', "icon_state" = "locked-y", "layer" = -X_PRED_LASER_LAYER)
-			apply_overlay(X_PRED_LASER_LAYER)
-	return TRUE
-
 /atom/proc/remove_pred_laser()
 	return FALSE
 
-/mob/living/carbon/human/remove_pred_laser()
+/mob/living/carbon/remove_pred_laser()
 	remove_overlay(PRED_LASER_LAYER)
-	return TRUE
-
-/mob/living/carbon/xenomorph/remove_pred_laser()
-	remove_overlay(X_PRED_LASER_LAYER)
 	return TRUE
 
 /obj/item/weapon/gun/energy/yautja/plasma_caster/process()

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -102,25 +102,16 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 /atom/proc/apply_laser()
 	return FALSE
 
-/mob/living/carbon/human/apply_laser()
+/mob/living/carbon/apply_laser()
 	overlays_standing[LASER_LAYER] = image("icon" = 'icons/obj/items/projectiles.dmi',"icon_state" = "sniper_laser", "layer" =-LASER_LAYER)
 	apply_overlay(LASER_LAYER)
-	return TRUE
-
-/mob/living/carbon/xenomorph/apply_laser()
-	overlays_standing[X_LASER_LAYER] = image("icon" = 'icons/obj/items/projectiles.dmi',"icon_state" = "sniper_laser", "layer" =-X_LASER_LAYER)
-	apply_overlay(X_LASER_LAYER)
 	return TRUE
 
 /mob/living/carbon/proc/remove_laser()
 	return FALSE
 
-/mob/living/carbon/human/remove_laser()
+/mob/living/carbon/remove_laser()
 	remove_overlay(LASER_LAYER)
-	return TRUE
-
-/mob/living/carbon/xenomorph/remove_laser()
-	remove_overlay(X_LASER_LAYER)
 	return TRUE
 
 /obj/item/weapon/gun/rifle/sniper/antimaterial/unique_action(mob/user)


### PR DESCRIPTION
## `Основные изменения`
https://github.com/tgstation/TerraGov-Marine-Corps/pull/14878
Ксеновская реген сила теперь отображается во вкладке статуса.

https://github.com/tgstation/TerraGov-Marine-Corps/pull/15112
Ксеновские и человеческие слои оверлеев объединенны в один.

https://github.com/tgstation/TerraGov-Marine-Corps/pull/15167
Исправлено то что включенные феромоны не тратили 5 плазмы в тик.
Оптимизировано использование `hud_set_plasma()` чтобы его не вызывало несколько раз в тик. Вместо этого плазма теперь обновляется только спец. проками, а плазма худ обновляется только после числа плазмы.
Optimises the use of hud_set_plasma() so its not getting called multiple times every life tick and other random times. Instead, plasma is now only updated by the setter procs, and plasma hud is only updated when plasma actually changes.
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
Квалити оф лайф, чище код, меньше багов
<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
qol: Сила регенерации ксеносов теперь отображается в панели статуса..
fix: Активные феромоны теперь тратят по 5 плазмы в тик как и положено.
code: Оптимизирован код апдейта плазмы.
code: Слои оверлеев ксеносов и хуманов объединены в один.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
