### PR TITLE
Fullscreen overlays and chat bullet act message cleanup

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -13,14 +13,13 @@
 		// needs to be recreated
 		clear_fullscreen(category, 0)
 		fullscreens[category] = screen = new type()
-		return screen
-
-	animate(screen)
-	deltimer(screen.removal_timer)
-	screen.removal_timer = null
-	screen.alpha = initial(screen.alpha)
-	if((!severity || severity == screen.severity) && (!client || screen.screen_loc != "CENTER-7,CENTER-7" || screen.fs_view == client.view))
-		return screen
+	else
+		animate(screen)
+		deltimer(screen.removal_timer)
+		screen.removal_timer = null
+		screen.alpha = initial(screen.alpha)
+		if((!severity || severity == screen.severity) && (!client || screen.screen_loc != "CENTER-7,CENTER-7" || screen.fs_view == client.view))
+			return screen
 
 	screen.icon_state = "[initial(screen.icon_state)][severity]"
 	screen.severity = severity

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -6,44 +6,47 @@
 	addtimer(CALLBACK(src, PROC_REF(clear_fullscreen), category, animated), duration)
 
 
+///Applies a fullscreen overlay
 /mob/proc/overlay_fullscreen(category, type, severity)
 	var/atom/movable/screen/fullscreen/screen = fullscreens[category]
-	if (!screen || screen.type != type)
+	if(!screen || screen.type != type)
 		// needs to be recreated
-		clear_fullscreen(category, FALSE)
+		clear_fullscreen(category, 0)
 		fullscreens[category] = screen = new type()
-	else if ((!severity || severity == screen.severity) && (!client || screen.screen_loc != "CENTER-7,CENTER-7" || screen.fs_view == client.view))
-		// doesn't need to be updated
+		return screen
+
+	animate(screen)
+	deltimer(screen.removal_timer)
+	screen.removal_timer = null
+	screen.alpha = initial(screen.alpha)
+	if((!severity || severity == screen.severity) && (!client || screen.screen_loc != "CENTER-7,CENTER-7" || screen.fs_view == client.view))
 		return screen
 
 	screen.icon_state = "[initial(screen.icon_state)][severity]"
 	screen.severity = severity
-	if (client && SHOULD_SHOW_TO(src, screen))
+	if(client && SHOULD_SHOW_TO(src, screen))
 		screen.update_for_view(client.view)
 		client.screen += screen
-
 	return screen
 
-
-/mob/proc/clear_fullscreen(category, animated = 10)
+///Removes a fullscreen overlay
+/mob/proc/clear_fullscreen(category, animated = 1 SECONDS)
 	var/atom/movable/screen/fullscreen/screen = fullscreens[category]
 	if(!screen)
 		return
+	if(!animated)
+		finish_clear_fullscreen(screen, category)
+		return
+	deltimer(screen.removal_timer)
+	screen.removal_timer = null
+	animate(screen, alpha = 0, time = animated)
+	screen.removal_timer = addtimer(CALLBACK(src, PROC_REF(finish_clear_fullscreen), screen, category), animated, TIMER_CLIENT_TIME|TIMER_STOPPABLE)
 
-	fullscreens -= category
-
-	if(animated)
-		animate(screen, alpha = 0, time = animated)
-		addtimer(CALLBACK(src, PROC_REF(clear_fullscreen_after_animate), screen), animated, TIMER_CLIENT_TIME)
-	else
-		if(client)
-			client.screen -= screen
-		qdel(screen)
-
-
-/mob/proc/clear_fullscreen_after_animate(atom/movable/screen/fullscreen/screen)
+///Actually removes the fullscreen overlay when ready
+/mob/proc/finish_clear_fullscreen(atom/movable/screen/fullscreen/screen, category)
 	if(client)
 		client.screen -= screen
+	fullscreens -= category
 	qdel(screen)
 
 
@@ -80,10 +83,13 @@
 	var/severity = 0
 	var/fs_view = WORLD_VIEW
 	var/show_when_dead = FALSE
+	///Holder for deletion timer
+	var/removal_timer
 
 
 /atom/movable/screen/fullscreen/Destroy()
-	severity = 0
+	deltimer(removal_timer)
+	removal_timer = null
 	return ..()
 
 

--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -67,12 +67,12 @@
 			verbs -= x
 		set_broken()
 
-/obj/machinery/computer/bullet_act(obj/projectile/Proj)
+/obj/machinery/computer/bullet_act(obj/projectile/proj)
 	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
-		visible_message("[Proj] ricochets off [src]!")
+		visible_message("[proj] ricochets off [src]!")
 		return 0
 	else
-		if(prob(round(Proj.ammo.damage /2)))
+		if(prob(round(proj.ammo.damage /2)))
 			set_broken()
 		..()
 		return 1

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -76,15 +76,17 @@
 		tforce = I.throwforce
 	take_damage(tforce, BRUTE, MELEE, 1, get_dir(src, AM))
 
-/obj/bullet_act(obj/projectile/P)
-	if(istype(P.ammo, /datum/ammo/xeno) && !(resistance_flags & XENO_DAMAGEABLE))
+
+/obj/bullet_act(obj/projectile/proj)
+	if(istype(proj.ammo, /datum/ammo/xeno) && !(resistance_flags & XENO_DAMAGEABLE))
 		return
 	. = ..()
-	if(P.damage < 1)
+	if(proj.damage < 1)
 		return
-	playsound(loc, P.hitsound, 50, 1)
-	visible_message(span_warning("\the [src] is damaged by \the [P]!"), visible_message_flags = COMBAT_MESSAGE)
-	take_damage(P.damage, P.ammo.damage_type, P.ammo.armor_type, 0, REVERSE_DIR(P.dir), P.ammo.penetration)
+	playsound(loc, proj.hitsound, 50, 1)
+	if(proj.damage > 30)
+		visible_message(span_warning("\the [src] is damaged by \the [proj]!"), visible_message_flags = COMBAT_MESSAGE)
+	take_damage(proj.damage, proj.ammo.damage_type, proj.ammo.armor_type, 0, REVERSE_DIR(proj.dir), proj.ammo.penetration)
 
 /obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = MELEE, effects = TRUE, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
 	user.do_attack_animation(src, ATTACK_EFFECT_SMASH)

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -163,14 +163,14 @@
 	add_overlay(overlay)
 
 
-/obj/structure/reagent_dispensers/fueltank/bullet_act(obj/projectile/Proj)
+/obj/structure/reagent_dispensers/fueltank/bullet_act(obj/projectile/proj)
 	if(exploding)
 		return FALSE
 
-	. = ..()
-
-	if(Proj.damage > 10 && prob(60) && (Proj.ammo.damage_type in list(BRUTE, BURN)))
+	if(proj.damage > 10 && prob(60) && (proj.ammo.damage_type in list(BRUTE, BURN)))
+		log_attack("[key_name(proj.firer)] detonated a fuel tank with a projectile at [AREACOORD(src)].")
 		explode()
+	return ..()
 
 /obj/structure/reagent_dispensers/fueltank/ex_act()
 	explode()

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -653,13 +653,13 @@
 		return
 	kill_hugger()
 
-/obj/item/clothing/mask/facehugger/bullet_act(obj/projectile/P)
+/obj/item/clothing/mask/facehugger/bullet_act(obj/projectile/proj)
 	..()
-	if(P.ammo.flags_ammo_behavior & AMMO_XENO)
+	if(proj.ammo.flags_ammo_behavior & AMMO_XENO)
 		return FALSE //Xeno spits ignore huggers.
-	if(P.damage && !(P.ammo.damage_type in list(OXY, STAMINA)))
+	if(proj.damage && !(proj.ammo.damage_type in list(OXY, STAMINA)))
 		kill_hugger()
-	P.ammo.on_hit_obj(src,P)
+	proj.ammo.on_hit_obj(src, proj)
 	return TRUE
 
 /obj/item/clothing/mask/facehugger/fire_act(exposed_temperature, exposed_volume)

--- a/code/modules/mob/living/simple_animal/friendly/parrot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/parrot.dm
@@ -167,7 +167,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(/datum/str
 		parrot_state = PARROT_SWOOP | PARROT_ATTACK //Attack other animals regardless
 		icon_state = icon_living
 
-/mob/living/simple_animal/parrot/bullet_act(obj/projectile/Proj)
+/mob/living/simple_animal/parrot/bullet_act(obj/projectile/proj)
 	. = ..()
 	if(!stat && !client)
 		if(parrot_state == PARROT_PERCH)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -114,11 +114,11 @@
 		face_atom(target) //Looks better if they keep looking at you when dodging
 
 
-/mob/living/simple_animal/hostile/bullet_act(obj/projectile/P)
+/mob/living/simple_animal/hostile/bullet_act(obj/projectile/proj)
 	if(stat == CONSCIOUS && !target && AIStatus != AI_OFF && !client)
-		if(P.firer && get_dist(src, P.firer) <= aggro_vision_range)
-			FindTarget(list(P.firer), 1)
-		Goto(P.starting_turf, move_to_delay, 3)
+		if(proj.firer && get_dist(src, proj.firer) <= aggro_vision_range)
+			FindTarget(list(proj.firer), 1)
+		Goto(proj.starting_turf, move_to_delay, 3)
 	return ..()
 
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -217,9 +217,9 @@
 	var/max_scatter = 360
 	///Maximum scatter when wielded
 	var/max_scatter_unwielded = 360
-	///How much scatter decays every X seconds
+	///How much scatter decays every decisecond
 	var/scatter_decay = 0
-	///How much scatter decays every X seconds when wielded
+	///How much scatter decays every decisecond
 	var/scatter_decay_unwielded = 0
 	///How much scatter increases per shot
 	var/scatter_increase = 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1216,19 +1216,13 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 //Turf handling.
 /turf/bullet_act(obj/projectile/proj)
 	. = ..()
-
-	var/list/mob_list = list() //Let's built a list of mobs on the bullet turf and grab one.
-	for(var/mob/possible_target in src)
-		mob_list += possible_target
-
-	if(!length(mob_list))
-		return FALSE
-
-	var/mob/picked_mob = pick(mob_list)
-	if(proj.projectile_hit(picked_mob))
+	var/mob/living/picked_mob = locate() in src
+	if(!picked_mob)
+		return ..()
+	if(picked_mob.projectile_hit(proj))
 		picked_mob.bullet_act(proj)
 		return TRUE
-	return FALSE
+	return ..()
 
 // walls can get shot and damaged, but bullets do much less.
 /turf/closed/wall/bullet_act(obj/projectile/proj)
@@ -1251,7 +1245,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(proj.ammo.flags_ammo_behavior & AMMO_BALLISTIC)
 		current_bulletholes++
 
-	if(prob(30))
+	if(damage >= 100)
 		visible_message(span_warning("[src] is damaged by [proj]!"), visible_message_flags = COMBAT_MESSAGE)
 	take_damage(damage)
 	return TRUE
@@ -1281,26 +1275,26 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 /mob/living/carbon/human/bullet_message(obj/projectile/proj, feedback_flags, damage)
 	. = ..()
-	var/list/victim_feedback = list()
-	if(proj.ammo.flags_ammo_behavior & AMMO_IS_SILENCED)
-		victim_feedback += "You've been shot in the [parse_zone(proj.def_zone)] by [proj]!"
-	else
-		victim_feedback += "You are hit by [proj] in the [parse_zone(proj.def_zone)]!"
-
-	if(feedback_flags & BULLET_FEEDBACK_IMMUNE)
-		victim_feedback += "Your armor deflects the impact!"
-	else if(feedback_flags & BULLET_FEEDBACK_SOAK)
-		victim_feedback += "Your armor absorbs the impact!"
-	else
-		if(feedback_flags & BULLET_FEEDBACK_PEN)
-			victim_feedback += "Your armor was penetrated!"
-		if(feedback_flags & BULLET_FEEDBACK_SHRAPNEL)
-			victim_feedback += "The impact sends <b>shrapnel</b> into the wound!"
-
-	if(feedback_flags & BULLET_FEEDBACK_FIRE)
-		victim_feedback += "You burst into <b>flames!!</b> Stop drop and roll!"
-
 	if(!client?.prefs.mute_self_combat_messages)
+		var/list/victim_feedback = list()
+		if(proj.shot_from && HAS_TRAIT(proj.shot_from, TRAIT_GUN_SILENCED))
+			victim_feedback += "You've been shot in the [parse_zone(proj.def_zone)] by [proj]!"
+		else
+			victim_feedback += "You are hit by [proj] in the [parse_zone(proj.def_zone)]!"
+
+		if(feedback_flags & BULLET_FEEDBACK_IMMUNE)
+			victim_feedback += "Your armor deflects the impact!"
+		else if(feedback_flags & BULLET_FEEDBACK_SOAK)
+			victim_feedback += "Your armor absorbs the impact!"
+		else
+			if(feedback_flags & BULLET_FEEDBACK_PEN)
+				victim_feedback += "Your armor was penetrated!"
+			if(feedback_flags & BULLET_FEEDBACK_SHRAPNEL)
+				victim_feedback += "The impact sends <b>shrapnel</b> into the wound!"
+
+		if(feedback_flags & BULLET_FEEDBACK_FIRE)
+			victim_feedback += "You burst into <b>flames!!</b> Stop drop and roll!"
+
 		to_chat(src, span_highdanger("[victim_feedback.Join(" ")]"))
 
 	if(feedback_flags & BULLET_FEEDBACK_SCREAM && stat == CONSCIOUS && !(species.species_flags & NO_PAIN))
@@ -1309,15 +1303,17 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(. != BULLET_MESSAGE_HUMAN_SHOOTER)
 		return
 	var/mob/living/carbon/human/firingMob = proj.firer
-	if(!firingMob.mind?.bypass_ff && !mind?.bypass_ff && firingMob.faction == faction && proj.ammo.damage_type != STAMINA)
+	if(!firingMob.mind?.bypass_ff && !mind?.bypass_ff && firingMob.faction == faction)
 		var/turf/T = get_turf(firingMob)
 		firingMob.ff_check(damage, src)
 		log_ffattack("[key_name(firingMob)] shot [key_name(src)] with [proj] in [AREACOORD(T)].")
 		msg_admin_ff("[ADMIN_TPMONTY(firingMob)] shot [ADMIN_TPMONTY(src)] with [proj] in [ADMIN_VERBOSEJMP(T)].")
 
-
 /mob/living/carbon/xenomorph/bullet_message(obj/projectile/proj, feedback_flags, damage)
 	. = ..()
+	if(client?.prefs.mute_self_combat_messages)
+		return
+
 	var/list/victim_feedback
 	if(proj.ammo.flags_ammo_behavior & AMMO_IS_SILENCED)
 		victim_feedback = list("We've been shot in the [parse_zone(proj.def_zone)] by [proj]!")
@@ -1337,8 +1333,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(feedback_flags & BULLET_FEEDBACK_SCREAM && stat == CONSCIOUS)
 		emote(prob(70) ? "hiss" : "roar")
 
-	if(!client?.prefs.mute_self_combat_messages)
-		to_chat(src, span_highdanger("[victim_feedback.Join(" ")]"))
+	to_chat(src, span_highdanger("[victim_feedback.Join(" ")]"))
 
 // Sundering procs
 /mob/living/proc/adjust_sunder(adjustment)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -40,11 +40,11 @@
 	smoke.set_up(0, src)
 	smoke.start()
 
-/obj/vehicle/ridden/atv/bullet_act(obj/projectile/P)
+/obj/vehicle/ridden/atv/bullet_act(obj/projectile/proj)
 	if(prob(50) || !buckled_mobs)
 		return ..()
 	for(var/mob/buckled_mob AS in buckled_mobs)
-		buckled_mob.bullet_act(P)
+		buckled_mob.bullet_act(proj)
 	return TRUE
 
 /obj/vehicle/ridden/atv/obj_destruction()

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -68,12 +68,12 @@
 	user.visible_message(span_danger("[user] hits [src]. Nothing happens."), null, null, COMBAT_MESSAGE_RANGE)
 	log_message("Attack by hand/paw (no damage). Attacker - [user].", LOG_MECHA, color="red")
 
-/obj/vehicle/sealed/mecha/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit) //wrapper
-	log_message("Hit by projectile. Type: [hitting_projectile]([hitting_projectile.ammo.damage_type]).", LOG_MECHA, color="red")
+/obj/vehicle/sealed/mecha/bullet_act(obj/projectile/proj, def_zone, piercing_hit) //wrapper
+	log_message("Hit by projectile. Type: [proj]([proj.ammo.damage_type]).", LOG_MECHA, color="red")
 	// yes we *have* to run the armor calc proc here I love tg projectile code too
 	try_damage_component(
-		modify_by_armor(hitting_projectile.damage, hitting_projectile.ammo.armor_type, hitting_projectile.ammo.penetration, attack_dir = REVERSE_DIR(hitting_projectile.dir)),
-		hitting_projectile.def_zone,
+		modify_by_armor(proj.damage, proj.ammo.armor_type, proj.ammo.penetration, attack_dir = REVERSE_DIR(proj.dir)),
+		proj.def_zone,
 	)
 	return ..()
 


### PR DESCRIPTION
## `Основные изменения`
Порт пр-ов с оффов.

Сообщения от попадания пули для чата не генерируются, если не будут использованы в дальнейшем.

Фуллскрин оверлеи теперь удаляются по таймеру, который при появлении новых оверлеев обновляется.
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
Меньше лагов, наверное
<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
