### PR TITLE
Nerfs bihexajuline and inaprovaline ods

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -34,17 +34,18 @@
 	return ..()
 
 /datum/reagent/medicine/inaprovaline/overdose_process(mob/living/L, metabolism)
-	L.jitter(5) //Overdose causes a spasm
-	L.Unconscious(40 SECONDS)
+	L.jitter(2) //Overdose causes a spasm
+	if(prob(15))
+		L.Unconscious(rand(5, 25))
 
 /datum/reagent/medicine/inaprovaline/overdose_crit_process(mob/living/L, metabolism)
 	L.setDrowsyness(L.drowsyness, 20)
 	if(ishuman(L)) //Critical overdose causes total blackout and heart damage. Too much stimulant
 		var/mob/living/carbon/human/H = L
 		var/datum/internal_organ/heart/E = H.get_organ_slot(ORGAN_SLOT_HEART)
-		E.take_damage(0.5*effect_str, TRUE)
+		E.take_damage(0.5 * effect_str, TRUE)
 	if(prob(10))
-		L.emote(pick("twitch","blink_r","shiver"))
+		L.emote(pick("twitch", "blink_r", "shiver"))
 
 /datum/reagent/medicine/ryetalyn
 	name = "Ryetalyn"
@@ -1322,16 +1323,15 @@
 	for(var/datum/limb/limb_to_unfix AS in host.limbs)
 		if(limb_to_unfix.limb_status & (LIMB_BROKEN | LIMB_SPLINTED | LIMB_STABILIZED | LIMB_DESTROYED | LIMB_AMPUTATED))
 			continue
-		limb_to_unfix.fracture()
+		if(prob(15))
+			limb_to_unfix.fracture()
 		break
-
 
 /datum/reagent/medicine/research
 	name = "Research precursor" //nothing with this subtype should be added to vendors
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	taste_description = "bitterness"
-
 
 /datum/reagent/medicine/research/quietus
 	name = "Quietus"


### PR DESCRIPTION
## `Основные изменения`
Бихексаджулин при передозе теперь ломает конечности не поочередно а при шансе в 15%.
Инапровалин больше не вешает 40 секунд сна при передозе (какой еблан это придумал), а лишь от 0.5 до 2.5 секунд сна с шансом в 15%
<!-- Опишите свой пулл реквест. -->

## `Как это улучшит игру`
Меньше пидорской хуйни в билде.
<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
balance: Передоз бихексаджулина теперь ломает кости с шансом в 15%, а не гарантированно
balance: Передоз инапровалина теперь вешает 0.5 - 2.5 секунд сна с шансом в 15% вместо 40 секунд сна.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
