### PR TITLE
Restricts xenos from opening storages with items.

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -538,6 +538,11 @@
 /obj/item/storage/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
+	if(isxeno(user))
+		if(istype(I, /obj/item/clothing/mask/facehugger) && can_be_inserted(I))
+			return handle_item_insertion(I, FALSE, user)
+		return FALSE
+
 	if(length(refill_types))
 		for(var/typepath in refill_types)
 			if(istype(I, typepath))


### PR DESCRIPTION
## `Основные изменения`
Теперь нельзя открыть контейнер если ты ксенос, а поместить туда можно только хаггеров (в качестве ловушек)
<!-- Опишите свой пулл реквест. -->

<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
fix: Ксеносы более не могут открывать контейнеры.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
