### PR TITLE
Fixes that you could use radial medical menu to use non-present in-hand items on someone.

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -44,11 +44,11 @@
 		return
 
 	var/datum/limb/affecting = user.client.prefs.toggles_gameplay & RADIAL_MEDICAL ? radial_medical(target, user) : target.get_limb(user.zone_selected)
-//RU TGMC EDIT
+	if(!user.get_active_held_item(src))
+		return
 	if(HAS_TRAIT(target, TRAIT_FOREIGN_BIO) && !alien)
 		to_chat(user, span_warning("\The [src] is incompatible with the biology of [target]!"))
 		return TRUE
-//RU TGMC EDIT
 	if(!affecting)
 		return FALSE
 

--- a/code/modules/radial/radial_body_select.dm
+++ b/code/modules/radial/radial_body_select.dm
@@ -23,17 +23,19 @@
 		radial_options[bodypart] = image(icon = 'icons/mob/radial.dmi', icon_state = radial_state)
 
 	//the list of the above
-	var/list/radial_options_show = list("head" = radial_options[BODY_ZONE_HEAD],
-									"chest" = radial_options[BODY_ZONE_CHEST],
-									"Rarm" = radial_options[BODY_ZONE_R_ARM],
-									"Rhand" = radial_options[BODY_ZONE_PRECISE_R_HAND],
-									"Rleg" = radial_options[BODY_ZONE_R_LEG],
-									"Rfoot" = radial_options[BODY_ZONE_PRECISE_R_FOOT],
-									"Lfoot" = radial_options[BODY_ZONE_PRECISE_L_FOOT],
-									"Lleg" = radial_options[BODY_ZONE_L_LEG],
-									"Lhand" = radial_options[BODY_ZONE_PRECISE_L_HAND],
-									"Larm" = radial_options[BODY_ZONE_L_ARM],
-									"groin" = radial_options[BODY_ZONE_PRECISE_GROIN])
+	var/list/radial_options_show = list(
+		"head" = radial_options[BODY_ZONE_HEAD],
+		"chest" = radial_options[BODY_ZONE_CHEST],
+		"Rarm" = radial_options[BODY_ZONE_R_ARM],
+		"Rhand" = radial_options[BODY_ZONE_PRECISE_R_HAND],
+		"Rleg" = radial_options[BODY_ZONE_R_LEG],
+		"Rfoot" = radial_options[BODY_ZONE_PRECISE_R_FOOT],
+		"Lfoot" = radial_options[BODY_ZONE_PRECISE_L_FOOT],
+		"Lleg" = radial_options[BODY_ZONE_L_LEG],
+		"Lhand" = radial_options[BODY_ZONE_PRECISE_L_HAND],
+		"Larm" = radial_options[BODY_ZONE_L_ARM],
+		"groin" = radial_options[BODY_ZONE_PRECISE_GROIN]\
+	)
 
 	var/datum/limb/affecting = null
 	var/choice = show_radial_menu(doctor, H, radial_options_show, null, 48, null, TRUE, null, 30)


### PR DESCRIPTION
## `Основные изменения`
Можно было открыть радиал медикал меню, положить предмет и уже без предмета в руке использовать предмет.
Как заставить радиал меню закрыться без предмета в руке я не разобрался.
<!-- Опишите свой пулл реквест. -->

<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
fix: Больше нельзя использовать медикал радиал меню для лечения без предмета в руке.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
