### PR TITLE
Increases sanity of mob swapping checks.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -12,6 +12,14 @@
 ///Move mod for going diagonally
 #define DIAG_MOVEMENT_ADDED_DELAY_MULTIPLIER (sqrt(2))
 
+//Mob swap modes, for mobs bumping other mobs
+
+///Mode for bumpint into the bumped mob
+#define NO_SWAP 0
+///Mode for swapping through the bumped mob
+#define SWAPPING 1
+///Mode for phasing through the bumped mob
+#define PHASING 2
 
 //Pain or shock reduction for different reagents
 #define PAIN_REDUCTION_VERY_LIGHT -5 //alkysine

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -75,3 +75,21 @@
 	if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
 		germ_level++
 	return ..()
+
+/mob/living/carbon/human/return_mob_swap_mode(mob/living/target)
+	if(isxeno(target))
+		return NO_SWAP
+	// the puller can always swap with its victim if on grab intent
+	if(target.pulledby == src && a_intent == INTENT_GRAB)
+		return SWAPPING
+	/* If we're moving diagonally, but the mob isn't on the diagonal destination turf and the destination turf is enterable we have no reason to shuffle/push them
+	 * However we also do not want mobs of smaller move forces being able to pass us diagonally if our move resist is larger, unless they're the same faction as us */
+	if(moving_diagonally && (get_dir(src, target) in GLOB.cardinals) && get_step(src, dir).Enter(src, loc) && (target.faction == faction || target.move_resist <= move_force))
+		return PHASING
+	// Restrained people act if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
+	else if(a_intent == INTENT_HELP || restrained())
+		if(move_force > target.move_resist)
+			return SWAPPING
+		else if(target.a_intent == INTENT_HELP || target.restrained())
+			return SWAPPING
+	return NO_SWAP

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -521,3 +521,21 @@ Returns TRUE when loc_weeds_type changes. Returns FALSE when it doesn’t change
 /mob/living/carbon/xenomorph/send_speech(message_raw, message_range = 7, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language=null, message_mode, tts_message, list/tts_filter)
 	. = ..()
 	playsound(loc, talk_sound, 25, 1)
+
+/mob/living/carbon/xenomorph/return_mob_swap_mode(mob/living/target)
+	// the puller can always swap with its victim if on grab intent
+	if(target.pulledby == src && a_intent == INTENT_GRAB)
+		return SWAPPING
+	/* If we're moving diagonally, but the mob isn't on the diagonal destination turf and the destination turf is enterable we have no reason to shuffle/push them
+	 * However we also do not want mobs of smaller move forces being able to pass us diagonally if our move resist is larger, unless they're the same faction as us */
+	if(moving_diagonally && (get_dir(src, target) in GLOB.cardinals) && get_step(src, dir).Enter(src, loc) && (target.faction == faction || target.move_resist <= move_force))
+		return PHASING
+	// Restrained people act if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
+	if(a_intent == INTENT_HELP || restrained())
+		// xenos swap with fellow xenos
+		if(get_xeno_hivenumber() == target.get_xeno_hivenumber())
+			return SWAPPING
+		// check for petrified targets
+		else if(move_force > target.move_resist)
+			return SWAPPING
+	return NO_SWAP

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -363,12 +363,13 @@
 			if(L.pulledby == src && a_intent == INTENT_GRAB)
 				mob_swap_mode = SWAPPING
 			// Restrained people act if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
-			else if((L.restrained() || L.a_intent == INTENT_HELP) && (restrained() || a_intent == INTENT_HELP) && L.move_force < MOVE_FORCE_VERY_STRONG)
-				mob_swap_mode = SWAPPING
-			else if(get_xeno_hivenumber() == L.get_xeno_hivenumber() && (L.pass_flags & PASS_XENO || pass_flags & PASS_XENO))
-				mob_swap_mode = PHASING
-			else if((move_resist >= MOVE_FORCE_VERY_STRONG || move_resist > L.move_force) && a_intent == INTENT_HELP) //Larger mobs can shove aside smaller ones. Xenos can always shove xenos
-				mob_swap_mode = SWAPPING
+			else if(a_intent == INTENT_HELP || restrained())
+				// xenos swap with xenos and almost whoever they want
+				if(isxeno(src) && (isxeno(L) || move_force > L.move_resist))
+					mob_swap_mode = SWAPPING
+				// if target isn't xeno and both are on help intents, but we don't want xenos to move petrified humans ,then we swap
+				else if(!isxeno(L) && move_force > L.move_resist && (L.a_intent == INTENT_HELP || L.restrained()))
+					mob_swap_mode = SWAPPING
 			/* If we're moving diagonally, but the mob isn't on the diagonal destination turf and the destination turf is enterable we have no reason to shuffle/push them
 			 * However we also do not want mobs of smaller move forces being able to pass us diagonally if our move resist is larger, unless they're the same faction as us
 			*/

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -367,8 +367,8 @@
 				// xenos swap with fellow xenos and almost whoever they want
 				if(isxeno(src) && (get_xeno_hivenumber() == L.get_xeno_hivenumber() || move_force > L.move_resist))
 					mob_swap_mode = SWAPPING
-				// if target isn't xeno and both are on help intents, and not petrified, then we swap
-				else if(!isxeno(L) && move_force > L.move_resist && (L.a_intent == INTENT_HELP || L.restrained()))
+				// if target isn't xeno, target isn't petrified, or we're not xeno, and both on help intents, then we swap
+				else if(!isxeno(L) && (move_force > L.move_resist || !isxeno(src)) && (L.a_intent == INTENT_HELP || L.restrained()))
 					mob_swap_mode = SWAPPING
 			/* If we're moving diagonally, but the mob isn't on the diagonal destination turf and the destination turf is enterable we have no reason to shuffle/push them
 			 * However we also do not want mobs of smaller move forces being able to pass us diagonally if our move resist is larger, unless they're the same faction as us

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -402,10 +402,10 @@
 
 /// Returns mob_swap_mode for Bump() with other mobs
 /mob/living/proc/return_mob_swap_mode(mob/living/target)
+	if(moving_diagonally && (get_dir(src, target) in GLOB.cardinals) && get_step(src, dir).Enter(src, loc) && (target.faction == faction || target.move_resist <= move_force))
+		return PHASING
 	if(move_force > target.move_resist || target.a_intent == INTENT_HELP || target.restrained())
 		return SWAPPING
-	if(moving_diagonally && (get_dir(src, target) in GLOB.cardinals) && get_step(src, dir).Enter(src, loc))
-		return PHASING
 	return NO_SWAP
 
 //Called when we want to push an atom/movable

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -331,10 +331,6 @@
 /mob/living/is_drawable(allowmobs = TRUE)
 	return (allowmobs && can_inject())
 
-#define NO_SWAP 0
-#define SWAPPING 1
-#define PHASING 2
-
 /mob/living/Bump(atom/A)
 	. = ..()
 	if(.) //We are thrown onto something.
@@ -358,23 +354,7 @@
 					return
 
 		if(!L.buckled && !L.anchored)
-			var/mob_swap_mode = NO_SWAP
-			// the puller can always swap with its victim if on grab intent
-			if(L.pulledby == src && a_intent == INTENT_GRAB)
-				mob_swap_mode = SWAPPING
-			// Restrained people act if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
-			else if(a_intent == INTENT_HELP || restrained())
-				// xenos swap with fellow xenos and almost whoever they want
-				if(isxeno(src) && (get_xeno_hivenumber() == L.get_xeno_hivenumber() || move_force > L.move_resist))
-					mob_swap_mode = SWAPPING
-				// if target isn't xeno, target isn't petrified, or we're not xeno, and both on help intents, then we swap
-				else if(!isxeno(L) && (move_force > L.move_resist || !isxeno(src)) && (L.a_intent == INTENT_HELP || L.restrained()))
-					mob_swap_mode = SWAPPING
-			/* If we're moving diagonally, but the mob isn't on the diagonal destination turf and the destination turf is enterable we have no reason to shuffle/push them
-			 * However we also do not want mobs of smaller move forces being able to pass us diagonally if our move resist is larger, unless they're the same faction as us
-			*/
-			if(moving_diagonally && (get_dir(src, L) in GLOB.cardinals) && (L.faction == faction || L.move_resist <= move_force) && get_step(src, dir).Enter(src, loc))
-				mob_swap_mode = PHASING
+			var/mob_swap_mode = return_mob_swap_mode(L)
 			if(mob_swap_mode)
 				//switch our position with L
 				if(loc && !loc.Adjacent(L.loc))
@@ -419,6 +399,14 @@
 			COOLDOWN_START(H, xeno_push_delay, XENO_HUMAN_PUSHED_DELAY)
 		if(PushAM(A))
 			return TURF_ENTER_ALREADY_MOVED
+
+/// Returns mob_swap_mode for Bump() with other mobs
+/mob/living/proc/return_mob_swap_mode(mob/living/target)
+	if(move_force > target.move_resist || target.a_intent == INTENT_HELP || target.restrained())
+		return SWAPPING
+	if(moving_diagonally && (get_dir(src, target) in GLOB.cardinals) && get_step(src, dir).Enter(src, loc))
+		return PHASING
+	return NO_SWAP
 
 //Called when we want to push an atom/movable
 /mob/living/proc/PushAM(atom/movable/AM, force = move_force)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -364,10 +364,10 @@
 				mob_swap_mode = SWAPPING
 			// Restrained people act if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
 			else if(a_intent == INTENT_HELP || restrained())
-				// xenos swap with xenos and almost whoever they want
-				if(isxeno(src) && (isxeno(L) || move_force > L.move_resist))
+				// xenos swap with fellow xenos and almost whoever they want
+				if(isxeno(src) && (get_xeno_hivenumber() == L.get_xeno_hivenumber() || move_force > L.move_resist))
 					mob_swap_mode = SWAPPING
-				// if target isn't xeno and both are on help intents, but we don't want xenos to move petrified humans ,then we swap
+				// if target isn't xeno and both are on help intents, and not petrified, then we swap
 				else if(!isxeno(L) && move_force > L.move_resist && (L.a_intent == INTENT_HELP || L.restrained()))
 					mob_swap_mode = SWAPPING
 			/* If we're moving diagonally, but the mob isn't on the diagonal destination turf and the destination turf is enterable we have no reason to shuffle/push them


### PR DESCRIPTION
## `Основные изменения`
Разделил часть в коде бампа, отвечающую за смену местами между мобами, на отдельные для людей и ксеносов. Читаемость как я надеюсь возросла, хоть и ценой небольшой копипасты.
Также проверка на диагональ теперь идёт первее проверок на свап, и потому при проходе по диагонали между ними, ты их не подвинешь.
## `Ченджлог`
```
:cl:
fix: Проход по диагонали между мобами теперь не меняет их местами с тобой.
/:cl:
```
