### PR TITLE
Re-adds alt-rmb for storages, moves hypospray and pill bottle interaction to attackby.

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -42,26 +42,6 @@
 	if(!in_range(A, user) || !user.Adjacent(A))
 		return FALSE
 
-	if(istype(A, /obj/item/storage/pill_bottle) && is_open_container()) //this should only run if its a pillbottle
-		var/obj/item/storage/pill_bottle/bottle = A
-		if(reagents.total_volume >= volume)
-			balloon_alert(user, "Hypospray is full.")
-			return  //early returning if its full
-
-		if(!length(bottle.contents))
-			return //early returning if its empty
-		var/obj/item/pill = bottle.contents[1]
-
-		if((pill.reagents.total_volume + reagents.total_volume) > volume)
-			balloon_alert(user, "Can't hold that much.")
-			return // so it doesnt let people have hypos more filled than their volume
-		pill.reagents.trans_to(src, pill.reagents.total_volume)
-
-		to_chat(user, span_notice("You dissolve [pill] from [bottle] in [src]."))
-		bottle.remove_from_storage(pill,null,user)
-		qdel(pill)
-		return
-
 	//For drawing reagents, will check if it's possible to draw, then draws.
 	if(inject_mode == HYPOSPRAY_INJECT_MODE_DRAW)
 		can_draw_reagent(A, user, FALSE)
@@ -71,7 +51,6 @@
 		balloon_alert(user, "Hypospray is Empty.")
 		return
 	if(!A.is_injectable() && !ismob(A))
-		A.balloon_alert(user, "Can't fill.")
 		return
 	if(skilllock && user.skills.getRating(SKILL_MEDICAL) < SKILL_MEDICAL_NOVICE)
 		user.visible_message(span_notice("[user] fumbles around figuring out how to use the [src]."),

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -297,6 +297,29 @@
 			new pill_type_to_fill(src)
 	update_icon()
 
+/obj/item/storage/pill_bottle/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/reagent_containers/hypospray))
+		var/obj/item/reagent_containers/hypospray/hypospray = I
+		if(hypospray.reagents.total_volume >= hypospray.volume)
+			balloon_alert(user, "Hypospray is full.")
+			return FALSE //early returning if its full
+
+		if(!length(contents))
+			return FALSE//early returning if its empty
+		var/obj/item/pill = contents[1]
+
+		if((pill.reagents.total_volume + hypospray.reagents.total_volume) > hypospray.volume)
+			balloon_alert(user, "Can't hold that much.")
+			return FALSE// so it doesnt let people have hypos more filled than their volume
+		pill.reagents.trans_to(I, pill.reagents.total_volume)
+
+		to_chat(user, span_notice("You dissolve [pill] from [src] in [I]."))
+		remove_from_storage(pill, null, user)
+		qdel(pill)
+		return TRUE
+
+	return ..()
+
 /obj/item/storage/pill_bottle/attack_self(mob/living/user)
 	if(user.get_inactive_held_item())
 		user.balloon_alert(user, "Need an empty hand")

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -553,6 +553,10 @@
 		return FALSE
 	return handle_item_insertion(I, FALSE, user)
 
+/obj/item/storage/AltRightClick(mob/user)
+	if(Adjacent(user) && !isxeno(user))
+		open(user)
+
 ///Refills the storage from the refill_types item
 /obj/item/storage/proc/do_refill(obj/item/storage/refiller, mob/user)
 	if(!length(refiller.contents))


### PR DESCRIPTION
## `Основные изменения`
Вернул Альт-ПКМ для контейнеров.
Перенёс растворение таблеток из таблетницы гипоспреем на уровень `attackby` чтобы оно работало корректно.
## `Ченджлог`
```
:cl:
fix: Возвращено открытие контейнеров на альт-пкм.
fix: Взаимодействие гипоспрея с таблетницами теперь работает как должно.
/:cl:
```
