### PR TITLE
new/old storage modules

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1114,6 +1114,8 @@
 		),
 		"Armor modules" = list(
 			/obj/item/armor_module/storage/general = -1,
+			/obj/item/armor_module/storage/ammo_mag = -1,
+			/obj/item/armor_module/storage/integrated = -1,
 			/obj/item/armor_module/storage/engineering = -1,
 			/obj/item/armor_module/storage/medical = -1,
 			/obj/item/armor_module/storage/injector = -1,


### PR DESCRIPTION
## `Основные изменения`

заметил что в игре есть пара "неиспользуемых" модулей
магазинный модуль (ammo_mag) вполне хорошо, не знаю почему его не было у маров
ис патерн (integrated) весьма спорный, но 0.2 слоу как для модуля хранения весьма жирно, но и хранит он как сатчел, если нужно потом будет забалансить поменяем