### PR TITLE
Praetorian toxin splash

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -33,7 +33,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1 SECONDS
-	spit_types = list(/datum/ammo/xeno/acid/heavy/passthrough)
+	spit_types = list(/datum/ammo/xeno/acid/heavy/passthrough, /datum/ammo/xeno/tox_loss/heavy)
 	acid_spray_duration = 6 SECONDS
 	acid_spray_damage = 8
 	acid_spray_duration = 10 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/predalien/castedatum_predalien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/predalien/castedatum_predalien.dm
@@ -1,6 +1,7 @@
 /datum/xeno_caste/predalien
 	caste_name = "Predalien"
 	display_name = "Abomination"
+	upgrade_name = ""
 	caste_type_path = /mob/living/carbon/xenomorph/predalien
 	tier = XENO_TIER_FOUR
 	upgrade = XENO_UPGRADE_BASETYPE

--- a/code/modules/projectiles/ammo_datums/xeno.dm
+++ b/code/modules/projectiles/ammo_datums/xeno.dm
@@ -48,6 +48,26 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	reagent_transfer_amount = 4
 	bullet_color = COLOR_LIGHT_ORANGE
 
+/datum/ammo/xeno/tox_loss
+	name = "toxin spit"
+	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS
+	spit_cost = 50
+	added_spit_delay = 0
+	damage_type = STAMINA
+	accurate_range = 5
+	max_range = 10
+	accuracy_var_low = 3
+	accuracy_var_high = 3
+	damage = 15
+	stagger_stacks = 1 SECONDS
+	slowdown_stacks = 1.5
+	bullet_color = COLOR_LIGHT_ORANGE
+	var/toxin_damage = 10
+
+/datum/ammo/xeno/tox_loss/on_hit_mob(mob/living/carbon/carbon_victim, obj/projectile/proj)
+	carbon_victim.apply_damage(toxin_damage, TOX, proj.def_zone, armor_type, updating_health = TRUE)
+	return ..()
+
 ///Set up the list of reagents the spit transfers upon impact
 /datum/ammo/xeno/toxin/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
@@ -120,6 +140,13 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	reagent_transfer_amount = 18
 	smoke_range = 1
 
+/datum/ammo/xeno/tox_loss/heavy //Praetorian
+	name = "toxin splash"
+	added_spit_delay = 0
+	spit_cost = 180
+	damage = 30
+	toxin_damage = 20
+
 /datum/ammo/xeno/sticky
 	name = "sticky resin spit"
 	icon_state = "sticky"
@@ -130,7 +157,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	spit_cost = 50
 	sound_hit = "alien_resin_build2"
 	sound_bounce = "alien_resin_build3"
-	damage = 20 //minor; this is mostly just to provide confirmation of a hit
+	damage = 40
 	max_range = 40
 	bullet_color = COLOR_PURPLE
 	stagger_stacks = 2


### PR DESCRIPTION
## `Основные изменения`

за место убранного нейроплевка добавил токсик сплеш, который не вводит нейро, но наносит урон токсом
плевку резиной увеличил стамин урон

пофиксил баг с двойным префиксом у абоминации

## `Как это улучшит игру`

мейк претор грейт аген? не уверен

