### PR TITLE
Fixes attachment handlers applying overlays while inhand.

### DIFF
--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -339,8 +339,10 @@
 		parent_item.overlays += overlay
 
 ///Updates the mob sprite of the attachment.
-/datum/component/attachment_handler/proc/apply_custom(datum/source, mutable_appearance/standing)
+/datum/component/attachment_handler/proc/apply_custom(datum/source, mutable_appearance/standing, inhands)
 	SIGNAL_HANDLER
+	if(inhands)
+		return
 	var/obj/item/parent_item = parent
 	if(!ismob(parent_item.loc))
 		return

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -1,4 +1,3 @@
-
 /obj/item/armor_module
 	name = "armor module"
 	desc = "A dis-figured armor module, in its prime this would've been a key item in your modular armor... now its just trash."
@@ -10,7 +9,6 @@
 
 	///Reference to parent modular armor suit.
 	var/obj/item/clothing/parent
-
 	///Slot the attachment is able to occupy.
 	var/slot
 	///Icon sheet of the attachment overlays
@@ -184,11 +182,3 @@
 		if(!armor_piece.secondary_color)
 			continue
 		armor_piece.handle_color(source, user, secondaries)
-
-/* RUTGMC DELETION, CAPES
-///Relays the extra controls to the user when the parent is examined.
-/obj/item/armor_module/armor/proc/extra_examine(datum/source, mob/user, list/examine_list)
-	SIGNAL_HANDLER
-	examine_list += "Right click the [parent] with paint to color [src]"
-*/
-

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -368,7 +368,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 /* --------------------------------------- */
 //For legacy support.
 /mob/living/carbon/human/regenerate_icons()
-	update_mutations(0)
 	update_inv_w_uniform()
 	update_inv_wear_id()
 	update_inv_gloves()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -365,7 +365,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		overlays_standing[TARGETED_LAYER] = I
 	apply_overlay(TARGETED_LAYER)
 
-
 /* --------------------------------------- */
 //For legacy support.
 /mob/living/carbon/human/regenerate_icons()
@@ -390,8 +389,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	update_burst()
 	UpdateDamageIcon()
 	update_transform()
-	update_headbite()
-
 
 /* --------------------------------------- */
 //vvvvvv UPDATE_INV PROCS vvvvvv

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -268,12 +268,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 	stand_icon.Blend(base_icon,ICON_OVERLAY)
 
-	/*
-	//Skin colour. Not in cache because highly variable (and relatively benign).
-	if (species.species_flags & HAS_SKIN_COLOR)
-		stand_icon.Blend(rgb(r_skin, g_skin, b_skin), ICON_ADD)
-	*/
-
 	if(has_head)
 		//Eyes
 		var/icon/eyes = new/icon('icons/mob/human_face.dmi', species.eyes)
@@ -422,7 +416,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 	apply_overlay(ID_LAYER)
 
-
 /mob/living/carbon/human/update_inv_gloves()
 	remove_overlay(GLOVES_LAYER)
 	if(gloves)
@@ -450,7 +443,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	bloodsies.color = blood_color
 	overlays_standing[GLOVES_LAYER] = bloodsies
 	apply_overlay(GLOVES_LAYER)
-
 
 /mob/living/carbon/human/update_inv_glasses()
 	remove_overlay(GLASSES_LAYER)
@@ -512,8 +504,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	overlays_standing[SUIT_STORE_LAYER] = s_store.make_worn_icon(species_type = species.name, slot_name = slot_s_store_str, default_icon = 'icons/mob/suit_slot.dmi', default_layer = SUIT_STORE_LAYER)
 	apply_overlay(SUIT_STORE_LAYER)
 
-
-
 /mob/living/carbon/human/update_inv_head()
 	remove_overlay(HEAD_LAYER)
 	if(!head)
@@ -541,7 +531,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 	apply_overlay(BELT_LAYER)
 
-
 /mob/living/carbon/human/update_inv_wear_suit()
 	remove_overlay(SUIT_LAYER)
 	species?.update_inv_wear_suit(src)
@@ -566,7 +555,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			r_store.screen_loc = ui_storage2
 			client.screen += r_store
 
-
 /mob/living/carbon/human/update_inv_wear_mask()
 	remove_overlay(FACEMASK_LAYER)
 	if(!wear_mask)
@@ -583,7 +571,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 	apply_overlay(FACEMASK_LAYER)
 
-
 /mob/living/carbon/human/update_inv_back()
 	remove_overlay(BACK_LAYER)
 	if(!back)
@@ -596,14 +583,12 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 	apply_overlay(BACK_LAYER)
 
-
 /mob/living/carbon/human/update_inv_handcuffed()
 	remove_overlay(HANDCUFF_LAYER)
 	if(!handcuffed)
 		return
 	overlays_standing[HANDCUFF_LAYER] = handcuffed.make_worn_icon(species_type = species.name, slot_name = slot_handcuffed_str, default_icon = 'icons/mob/mob.dmi', default_layer = HANDCUFF_LAYER)
 	apply_overlay(HANDCUFF_LAYER)
-
 
 /mob/living/carbon/human/update_inv_r_hand()
 	remove_overlay(R_HAND_LAYER)
@@ -617,7 +602,6 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 	apply_overlay(R_HAND_LAYER)
 
-
 /mob/living/carbon/human/update_inv_l_hand()
 	remove_overlay(L_HAND_LAYER)
 	if(!l_hand)
@@ -630,13 +614,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	overlays_standing[L_HAND_LAYER] = l_hand.make_worn_icon(species_type = species.name, inhands = TRUE, slot_name = slot_l_hand_str, default_icon = 'icons/mob/items_lefthand_1.dmi', default_layer = L_HAND_LAYER)
 	apply_overlay(L_HAND_LAYER)
 
-
-// Used mostly for creating head items
+/// Used mostly for creating head items
 /mob/living/carbon/human/proc/generate_head_icon()
-//gender no longer matters for the mouth, although there should probably be seperate base head icons.
-//	var/g = "m"
-//	if (gender == FEMALE)	g = "f"
-
 	//base icons
 	var/icon/face_lying = new /icon('icons/mob/human_face.dmi',"bald_l")
 
@@ -687,8 +666,10 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	remove_overlay(FIRE_LAYER)
 	if(on_fire)
 		switch(fire_stacks)
-			if(1 to 14)	overlays_standing[FIRE_LAYER] = mutable_appearance('icons/mob/OnFire.dmi', "Standing_weak", -FIRE_LAYER)
-			if(15 to 20) overlays_standing[FIRE_LAYER] = mutable_appearance('icons/mob/OnFire.dmi', "Standing_medium", -FIRE_LAYER)
+			if(1 to 14)
+				overlays_standing[FIRE_LAYER] = mutable_appearance('icons/mob/OnFire.dmi', "Standing_weak", -FIRE_LAYER)
+			if(15 to 20)
+				overlays_standing[FIRE_LAYER] = mutable_appearance('icons/mob/OnFire.dmi', "Standing_medium", -FIRE_LAYER)
 
 		apply_overlay(FIRE_LAYER)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -397,7 +397,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if(wear_suit?.flags_inv_hide & HIDEJUMPSUIT)
 		return
 
-	overlays_standing[UNIFORM_LAYER] = w_uniform.make_worn_icon(species_type = species.name, slot_name = slot_w_uniform_str, default_icon = 'icons/mob/clothing/uniforms/uniform_0.dmi', default_layer = UNIFORM_LAYER)
+	overlays_standing[UNIFORM_LAYER] = w_uniform.make_worn_icon(species.name, slot_w_uniform_str, default_icon = 'icons/mob/clothing/uniforms/uniform_0.dmi', default_layer = UNIFORM_LAYER)
 
 	apply_overlay(UNIFORM_LAYER)
 	species?.update_inv_w_uniform(src)
@@ -412,7 +412,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		client.screen += wear_id
 
 	if(w_uniform?.displays_id || istype(wear_id, /obj/item/card/id/dogtag))
-		overlays_standing[ID_LAYER] = wear_id.make_worn_icon(species_type = species.name, slot_name = slot_wear_id_str, default_icon = 'icons/mob/mob.dmi', default_layer = ID_LAYER)
+		overlays_standing[ID_LAYER] = wear_id.make_worn_icon(species.name, slot_wear_id_str, default_icon = 'icons/mob/mob.dmi', default_layer = ID_LAYER)
 
 	apply_overlay(ID_LAYER)
 
@@ -422,7 +422,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(client && hud_used?.hud_shown && hud_used.inventory_shown)
 			gloves.screen_loc = ui_gloves
 			client.screen += gloves
-		overlays_standing[GLOVES_LAYER] = gloves.make_worn_icon(species_type = species.name, slot_name = slot_gloves_str, default_icon = 'icons/mob/clothing/hands.dmi', default_layer = GLOVES_LAYER)
+		overlays_standing[GLOVES_LAYER] = gloves.make_worn_icon(species.name, slot_gloves_str, default_icon = 'icons/mob/clothing/hands.dmi', default_layer = GLOVES_LAYER)
 		apply_overlay(GLOVES_LAYER)
 		return
 
@@ -434,11 +434,11 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if(left_hand.limb_status & LIMB_DESTROYED)
 		if(right_hand.limb_status & LIMB_DESTROYED)
 			return //No hands.
-		bloodsies = mutable_appearance(icon = 'icons/effects/blood.dmi', icon_state = "bloodyhand_right") //Only right hand.
+		bloodsies = mutable_appearance('icons/effects/blood.dmi', "bloodyhand_right") //Only right hand.
 	else if(right_hand.limb_status & LIMB_DESTROYED)
-		bloodsies = mutable_appearance(icon = 'icons/effects/blood.dmi', icon_state = "bloodyhand_left") //Only left hand.
+		bloodsies = mutable_appearance('icons/effects/blood.dmi', "bloodyhand_left") //Only left hand.
 	else
-		bloodsies = mutable_appearance(icon = 'icons/effects/blood.dmi', icon_state = "bloodyhands") //Both hands.
+		bloodsies = mutable_appearance('icons/effects/blood.dmi', "bloodyhands") //Both hands.
 
 	bloodsies.color = blood_color
 	overlays_standing[GLOVES_LAYER] = bloodsies
@@ -457,7 +457,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if(glasses.goggles_layer)
 		glasses_layer = GOGGLES_LAYER
 
-	overlays_standing[glasses_layer] = glasses.make_worn_icon(species_type = species.name, slot_name = slot_glasses_str, default_icon = 'icons/mob/clothing/eyes.dmi', default_layer = glasses_layer)
+	overlays_standing[glasses_layer] = glasses.make_worn_icon(species.name, slot_glasses_str, default_icon = 'icons/mob/clothing/eyes.dmi', default_layer = glasses_layer)
 	apply_overlay(glasses_layer)
 
 /mob/living/carbon/human/update_inv_ears()
@@ -471,7 +471,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	if((head?.flags_inv_hide & HIDEEARS) || (wear_mask?.flags_inv_hide & HIDEEARS))
 		return
 
-	overlays_standing[EARS_LAYER] = wear_ear.make_worn_icon(species_type = species.name, slot_name = slot_ear_str, default_icon = 'icons/mob/clothing/ears.dmi', default_layer = EARS_LAYER)
+	overlays_standing[EARS_LAYER] = wear_ear.make_worn_icon(species.name, slot_ear_str, default_icon = 'icons/mob/clothing/ears.dmi', default_layer = EARS_LAYER)
 	apply_overlay(EARS_LAYER)
 
 /mob/living/carbon/human/update_inv_shoes()
@@ -484,7 +484,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		return
 
 	if(shoes)
-		overlays_standing[SHOES_LAYER] = shoes.make_worn_icon(species_type = species.name, slot_name = slot_shoes_str, default_icon = 'icons/mob/clothing/feet.dmi', default_layer = SHOES_LAYER)
+		overlays_standing[SHOES_LAYER] = shoes.make_worn_icon(species.name, slot_shoes_str, default_icon = 'icons/mob/clothing/feet.dmi', default_layer = SHOES_LAYER)
 	else if(feet_blood_color)
 		var/mutable_appearance/bloodsies = mutable_appearance(icon = 'icons/effects/blood.dmi', icon_state = "shoeblood")
 		bloodsies.color = feet_blood_color
@@ -501,7 +501,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		s_store.screen_loc = ui_sstore1
 		client.screen += s_store
 
-	overlays_standing[SUIT_STORE_LAYER] = s_store.make_worn_icon(species_type = species.name, slot_name = slot_s_store_str, default_icon = 'icons/mob/suit_slot.dmi', default_layer = SUIT_STORE_LAYER)
+	overlays_standing[SUIT_STORE_LAYER] = s_store.make_worn_icon(species.name, slot_s_store_str, default_icon = 'icons/mob/suit_slot.dmi', default_layer = SUIT_STORE_LAYER)
 	apply_overlay(SUIT_STORE_LAYER)
 
 /mob/living/carbon/human/update_inv_head()
@@ -513,7 +513,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		head.screen_loc = ui_head
 		client.screen += head
 
-	overlays_standing[HEAD_LAYER] = head.make_worn_icon(species_type = species.name, slot_name = slot_head_str, default_icon = 'icons/mob/clothing/headwear/head_0.dmi', default_layer = HEAD_LAYER)
+	overlays_standing[HEAD_LAYER] = head.make_worn_icon(species.name, slot_head_str, default_icon = 'icons/mob/clothing/headwear/head_0.dmi', default_layer = HEAD_LAYER)
 
 	apply_overlay(HEAD_LAYER)
 	species?.update_inv_head(src)
@@ -527,7 +527,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		belt.screen_loc = ui_belt
 		client.screen += belt
 
-	overlays_standing[BELT_LAYER] = belt.make_worn_icon(species_type = species.name, slot_name = slot_belt_str, default_icon = 'icons/mob/clothing/belt.dmi', default_layer = BELT_LAYER)
+	overlays_standing[BELT_LAYER] = belt.make_worn_icon(species.name, slot_belt_str, default_icon = 'icons/mob/clothing/belt.dmi', default_layer = BELT_LAYER)
 
 	apply_overlay(BELT_LAYER)
 
@@ -541,7 +541,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		wear_suit.screen_loc = ui_oclothing
 		client.screen += wear_suit
 
-	overlays_standing[SUIT_LAYER] = wear_suit.make_worn_icon(species_type = species.name, slot_name = slot_wear_suit_str, default_icon = 'icons/mob/clothing/suits/suit_0.dmi', default_layer = SUIT_LAYER)
+	overlays_standing[SUIT_LAYER] = wear_suit.make_worn_icon(species.name, slot_wear_suit_str, default_icon = 'icons/mob/clothing/suits/suit_0.dmi', default_layer = SUIT_LAYER)
 
 	apply_overlay(SUIT_LAYER)
 
@@ -567,7 +567,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		wear_mask.screen_loc = ui_mask
 		client.screen += wear_mask
 
-	overlays_standing[FACEMASK_LAYER] = wear_mask.make_worn_icon(species_type = species.name, slot_name = slot_wear_mask_str, default_icon = 'icons/mob/clothing/mask.dmi', default_layer = FACEMASK_LAYER)
+	overlays_standing[FACEMASK_LAYER] = wear_mask.make_worn_icon(species.name, slot_wear_mask_str, default_icon = 'icons/mob/clothing/mask.dmi', default_layer = FACEMASK_LAYER)
 
 	apply_overlay(FACEMASK_LAYER)
 
@@ -579,7 +579,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		back.screen_loc = ui_back
 		client.screen += back
 
-	overlays_standing[BACK_LAYER] = back.make_worn_icon(species_type = species.name, slot_name = slot_back_str, default_icon = 'icons/mob/clothing/back.dmi', default_layer = BACK_LAYER)
+	overlays_standing[BACK_LAYER] = back.make_worn_icon(species.name, slot_back_str, default_icon = 'icons/mob/clothing/back.dmi', default_layer = BACK_LAYER)
 
 	apply_overlay(BACK_LAYER)
 
@@ -587,7 +587,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	remove_overlay(HANDCUFF_LAYER)
 	if(!handcuffed)
 		return
-	overlays_standing[HANDCUFF_LAYER] = handcuffed.make_worn_icon(species_type = species.name, slot_name = slot_handcuffed_str, default_icon = 'icons/mob/mob.dmi', default_layer = HANDCUFF_LAYER)
+	overlays_standing[HANDCUFF_LAYER] = handcuffed.make_worn_icon(species.name, slot_handcuffed_str, default_icon = 'icons/mob/mob.dmi', default_layer = HANDCUFF_LAYER)
 	apply_overlay(HANDCUFF_LAYER)
 
 /mob/living/carbon/human/update_inv_r_hand()
@@ -598,7 +598,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		client.screen += r_hand
 		r_hand.screen_loc = ui_rhand
 
-	overlays_standing[R_HAND_LAYER] = r_hand.make_worn_icon(species_type = species.name, inhands = TRUE, slot_name = slot_r_hand_str, default_icon = 'icons/mob/items_righthand_1.dmi', default_layer = R_HAND_LAYER)
+	overlays_standing[R_HAND_LAYER] = r_hand.make_worn_icon(species.name, slot_r_hand_str, TRUE, 'icons/mob/items_righthand_1.dmi', R_HAND_LAYER)
 
 	apply_overlay(R_HAND_LAYER)
 
@@ -611,7 +611,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		client.screen += l_hand
 		l_hand.screen_loc = ui_lhand
 
-	overlays_standing[L_HAND_LAYER] = l_hand.make_worn_icon(species_type = species.name, inhands = TRUE, slot_name = slot_l_hand_str, default_icon = 'icons/mob/items_lefthand_1.dmi', default_layer = L_HAND_LAYER)
+	overlays_standing[L_HAND_LAYER] = l_hand.make_worn_icon(species.name, slot_l_hand_str, TRUE, 'icons/mob/items_lefthand_1.dmi', L_HAND_LAYER)
 	apply_overlay(L_HAND_LAYER)
 
 /// Used mostly for creating head items

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -45,8 +45,6 @@
 	hud_set_firestacks()
 
 /mob/living/carbon/xenomorph/regenerate_icons()
-	..()
-
 	update_inv_r_hand()
 	update_inv_l_hand()
 	update_icons()

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -66,6 +66,3 @@
 
 /mob/proc/update_burst()
 	return
-
-/mob/proc/update_headbite()
-	return

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -40,9 +40,6 @@
 /mob/proc/update_inv_gloves()
 	return
 
-/mob/proc/update_mutations()
-	return
-
 /mob/proc/update_inv_wear_id()
 	return
 


### PR DESCRIPTION
## `Основные изменения`
Плащи, камы, разгрузки и прочая ересь больше не будет цеплять свой оверлей при поднятии в руки.
Также почистил код от ненужного хлама.
## `Ченджлог`
```
:cl:
fix: Плащи, камы, разгрузки и прочий подобный хлам больше не будут цеплять свои оверлеи при нахождении в руках.
/:cl:
```
