### PR TITLE
Changed names and descriptions of credit coins.

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(marine_gear_listed_products, list(
 	/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MARINE, "Oxycodone autoinjector", 5, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/russian_red = list(CAT_MARINE, "Emergency autoinjecto", 10, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine	 = list(CAT_MARINE, "Synaptizine autoinjector", 8, "cyan"),
-	/obj/item/research_product/money/basic = list(CAT_MARINE, "credits - 50", 8, "white"),
+	/obj/item/research_product/money/basic = list(CAT_MARINE, "50 credits coin", 8, "yellow2"),
 ))
 
 GLOBAL_LIST_INIT(robot_gear_listed_products, list(
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(robot_gear_listed_products, list(
 	/obj/item/cell/lasgun/lasrifle/recharger = list(CAT_ROBOT, "Terra Experimental recharger battery", 4, "orange2"),
 	/obj/item/tool/handheld_charger = list(CAT_ROBOT, "Hand-held cell charger", 5, "yellow"),
 	/obj/item/weapon/powerfist = list(CAT_ROBOT, "Powerfist", 10, "red"),
-	/obj/item/research_product/money/basic = list(CAT_ROBOT, "credits - 50", 8, "white"),
+	/obj/item/research_product/money/basic = list(CAT_ROBOT, "50 credits coin", 8, "yellow2"),
 ))
 
 GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 	/obj/item/mortal_shell/smoke = list(CAT_ENGSUP, "Smoke Mortar shell", 1, "orange2"),
 	/obj/item/mortal_shell/flare = list(CAT_ENGSUP, "Flare Mortar shell", 1, "orange2"),
 	/obj/item/ammo_magazine/flamer_tank/large = list(CAT_ENGSUP, "Flamethrower tank", 1, "orange2"),
-	/obj/item/research_product/money/basic = list(CAT_ENGSUP, "credits - 50", 8, "white"),
+	/obj/item/research_product/money/basic = list(CAT_ENGSUP, "50 credits coin", 8, "yellow2"),
 ))
 
 GLOBAL_LIST_INIT(medic_gear_listed_products, list(
@@ -166,7 +166,7 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 	/obj/item/defibrillator/advanced = list(CAT_MEDSUP, "advanced emergency defibrillator", 4, "yellow"),
 	/obj/item/tweezers_advanced = list(CAT_MEDSUP, "Advanced Tweezers", 8, "yellow"),
 	/obj/effect/vendor_bundle/stretcher = list(CAT_MEDSUP, "Medivac Stretcher", 20, "yellow"),
-	/obj/item/research_product/money/basic = list(CAT_MEDSUP, "credits - 50", 8, "white"),
+	/obj/item/research_product/money/basic = list(CAT_MEDSUP, "50 credits coin", 8, "yellow2"),
 ))
 
 GLOBAL_LIST_INIT(leader_gear_listed_products, list(
@@ -222,7 +222,7 @@ GLOBAL_LIST_INIT(leader_gear_listed_products, list(
 	/obj/item/storage/firstaid/adv = list(CAT_LEDSUP, "Advanced firstaid kit", 1, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_LEDSUP, "Injector (Synaptizine)", 2, "cyan"),
 	/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_LEDSUP, "Injector (Advanced)", 2, "cyan"),
-	/obj/item/research_product/money/basic = list(CAT_LEDSUP, "credits - 50", 8, "white"),
+	/obj/item/research_product/money/basic = list(CAT_LEDSUP, "50 credits coin", 8, "yellow2"),
 ))
 
 GLOBAL_LIST_INIT(commander_gear_listed_products, list(
@@ -305,7 +305,7 @@ GLOBAL_LIST_INIT(commander_gear_listed_products, list(
 	/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_FCSUP, "Injector (Advanced)", 2, "cyan"),
 	/obj/item/stack/medical/heal_pack/advanced/bruise_combat_pack = list(CAT_FCSUP, "Combat Trauma Kit", 2, "cyan"),
 	/obj/item/stack/medical/heal_pack/advanced/burn_combat_pack = list(CAT_FCSUP, "Combat Burn Kit", 2, "cyan"),
-	/obj/item/research_product/money/basic = list(CAT_FCSUP, "credits - 50", 8, "white"),
+	/obj/item/research_product/money/basic = list(CAT_FCSUP, "50 credits coin", 8, "yellow2"),
 ))
 
 //A way to give them everything at once that still works with loadouts would be nice, but barring that make sure that your point calculation is set up so they don't get more than what they're supposed to
@@ -330,7 +330,7 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/ammo_magazine/rifle/standard_spottingrifle/plasmaloss = list(CAT_SGSUP, "SG-153 Spotting Rifle Tanglefoot Magazine", 3, "orange2"),
 	/obj/item/ammo_magazine/rifle/standard_spottingrifle/incendiary = list(CAT_SGSUP, "SG-153 Spotting Rifle Incendiary Magazine", 3, "orange2"),
 	/obj/item/ammo_magazine/pistol/standard_pistol/smart_pistol = list(CAT_SGSUP, "SP-13 smart pistol ammo", 2, "orange2"),
-	/obj/item/research_product/money/basic = list(CAT_SGSUP, "credits - 50", 6, "white"),
+	/obj/item/research_product/money/basic = list(CAT_SGSUP, "50 credits coin", 6, "yellow2"),
 ))
 
 GLOBAL_LIST_INIT(synthetic_gear_listed_products, list(
@@ -392,7 +392,7 @@ GLOBAL_LIST_INIT(synthetic_gear_listed_products, list(
 	/obj/item/tweezers_advanced = list(CAT_SYNTH, "Advanced Tweezers", 8, "yellow"),
 	/obj/item/tool/surgery/scalpel/manager = list(CAT_SYNTH, "Incision Management System", 6, "yellow"),
 	/obj/effect/vendor_bundle/stretcher = list(CAT_SYNTH, "Medivac Stretcher", 20, "yellow"),
-	/obj/item/research_product/money/basic = list(CAT_SYNTH, "credits - 50", 8, "white"),
+	/obj/item/research_product/money/basic = list(CAT_SYNTH, "50 credits coin", 8, "yellow2"),
 ))
 
 ///Assoc list linking the job title with their specific points vendor

--- a/code/game/objects/machinery/research.dm
+++ b/code/game/objects/machinery/research.dm
@@ -312,22 +312,22 @@
 	GLOB.round_statistics.points_from_research += export_points
 	return new /datum/export_report(export_points, name, faction_selling)
 
-/obj/item/research_product/money/examine(user)
-	. = ..()
-	. += span_notice("Rewards export points, as the name suggests.")
-
 /obj/item/research_product/money/basic
-	name = "credits - 50"
+	name = "50 credits coin"
+	desc = "A coin containing rare materials worth for 50 credits."
 	export_points = 50
 
 /obj/item/research_product/money/common
-	name = "credits - 150"
+	name = "150 credits coin"
+	desc = "A coin containing rare materials worth for 150 credits."
 	export_points = 150
 
 /obj/item/research_product/money/uncommon
-	name = "credits - 250"
+	name = "250 credits coin"
+	desc = "A coin containing rare materials worth for 250 credits."
 	export_points = 250
 
 /obj/item/research_product/money/rare
-	name = "credits - 800"
+	name = "800 credits coin"
+	desc = "A coin containing rare materials worth for 800 credits."
 	export_points = 800

--- a/tgui/packages/tgui/interfaces/MarineSelector.js
+++ b/tgui/packages/tgui/interfaces/MarineSelector.js
@@ -163,6 +163,11 @@ const ItemLine = (props, context) => {
               Tool
             </Box>
           )}
+          {prod_color === 'yellow2' && (
+            <Box inline mr="6px" ml="6px" color="yellow">
+              Money
+            </Box>
+          )}
           {prod_color === 'blue' && (
             <Box inline mr="6px" ml="6px" color="blue">
               Specialist


### PR DESCRIPTION
## `Основные изменения`
Добавил нормальные названия и описания монеткам.
Также изменил категорию в вендоре.
![image](https://github.com/user-attachments/assets/8f754488-4d01-4a06-87ae-8f8d95f0967c)
## `Как это улучшит игру`
Нормальные описания.
## `Ченджлог`
```
:cl:
spellcheck: Добавлены нормальные названия и описания монеткам из ресерча.
/:cl:
```
