### PR TITLE
Fixes removing b7 smart scope not removing aiming traits.

### DIFF
--- a/code/modules/projectiles/attachables/_attachable.dm
+++ b/code/modules/projectiles/attachables/_attachable.dm
@@ -277,6 +277,10 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		if(add_aim_mode)
 			var/datum/action/item_action/aim_mode/action_to_delete = locate() in master_gun.actions
 			QDEL_NULL(action_to_delete)
+			if(HAS_TRAIT(master_gun, TRAIT_GUN_AUTO_AIM_MODE))
+				REMOVE_TRAIT(master_gun, TRAIT_GUN_AUTO_AIM_MODE, GUN_TRAIT)
+			if(HAS_TRAIT(master_gun, TRAIT_GUN_IS_AIMING))
+				REMOVE_TRAIT(master_gun, TRAIT_GUN_IS_AIMING, GUN_TRAIT)
 		if(delay_mod)
 			master_gun.modify_fire_delay(-delay_mod)
 		if(burst_delay_mod)


### PR DESCRIPTION
## `Основные изменения`
При отсоединении прицелов дающих прицеливание, при включенном прицеливании больше не будет даваться прицеливание без возможности выключить.
## `Ченджлог`
```
:cl:
fix: Отсоединение прицелов дающих аим мод теперь отключает его если он был включен.
/:cl:
```
