### PR TITLE
Increases possible transfer amounts for hyposprays.

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -8,6 +8,7 @@
 	init_reagent_flags = DRAWABLE
 	amount_per_transfer_from_this = 15
 	volume = 45
+	possible_transfer_amounts = list(1, 3, 5, 10, 15, 20, 30, 45)
 	list_reagents = list(/datum/reagent/consumable/sodiumchloride = 45)
 
 /obj/item/reagent_containers/hypospray/autoinjector/update_icon_state()

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -203,7 +203,7 @@
 	icon_state = "beakerbluespace"
 	volume = 300
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5, 10, 15, 20, 30, 50, 100, 150, 300)
+	possible_transfer_amounts = list(5, 10, 15, 20, 30, 50, 60, 100, 120, 150, 300)
 
 /obj/item/reagent_containers/glass/beaker/vial
 	name = "vial"

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -159,19 +159,19 @@
 
 		var/percent = round((reagents.total_volume / volume) * 100)
 		switch(percent)
-			if(0 to 9)			
+			if(0 to 9)
 				filling.icon_state = "[icon_state]-10"
-			if(10 to 24) 		
+			if(10 to 24)
 				filling.icon_state = "[icon_state]10"
-			if(25 to 49)		
+			if(25 to 49)
 				filling.icon_state = "[icon_state]25"
-			if(50 to 74)		
+			if(50 to 74)
 				filling.icon_state = "[icon_state]50"
-			if(75 to 79)		
+			if(75 to 79)
 				filling.icon_state = "[icon_state]75"
-			if(80 to 90)		
+			if(80 to 90)
 				filling.icon_state = "[icon_state]80"
-			if(91 to INFINITY)	
+			if(91 to INFINITY)
 				filling.icon_state = "[icon_state]100"
 
 		filling.color = mix_color_from_reagents(reagents.reagent_list)
@@ -203,7 +203,7 @@
 	icon_state = "beakerbluespace"
 	volume = 300
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,30,40,60,120,300)
+	possible_transfer_amounts = list(5, 10, 15, 20, 30, 50, 100, 150, 300)
 
 /obj/item/reagent_containers/glass/beaker/vial
 	name = "vial"
@@ -211,7 +211,7 @@
 	icon_state = "vial"
 	volume = 30
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,25)
+	possible_transfer_amounts = list(5, 10, 15, 30)
 
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list(/datum/reagent/medicine/cryoxadone = 30)
@@ -288,11 +288,11 @@
 	if(reagents.total_volume)
 		var/percent = round((reagents.total_volume / volume) * 100)
 		switch(percent)
-			if(0 to 9)			
+			if(0 to 9)
 				icon_state = "janibucket"
-			if(10 to 65) 		
+			if(10 to 65)
 				icon_state = "janibucket_half"
-			if(66 to INFINITY)	
+			if(66 to INFINITY)
 				icon_state = "janibucket_full"
 	else
 		icon_state = "janibucket"

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -9,7 +9,7 @@
 	item_state = "hypo"
 	icon_state = "hypo"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(1, 3, 5, 10, 15, 20, 30)
+	possible_transfer_amounts = list(1, 3, 5, 10, 15, 20, 30, 60, 120)
 	volume = 120
 	init_reagent_flags = OPENCONTAINER
 	flags_equip_slot = ITEM_SLOT_BELT
@@ -538,6 +538,7 @@
 	icon_state = "hypomed"
 	core_name = "hypospray"
 	volume = 240
+	possible_transfer_amounts = list(1, 3, 5, 10, 15, 20, 30, 60, 120, 240)
 
 /obj/item/reagent_containers/hypospray/advanced/big/bicaridine
 	name = "big bicaridine hypospray"


### PR DESCRIPTION
## `Основные изменения`
Автоинжекторы теперь могут вводить реагентов вплоть до 45.
Обычные гипоспреи до 120.
Улучшенные до 240.
## `Как это улучшит игру`
Удобство.
## `Ченджлог`
```
:cl:
qol: Увеличен максимально возможно вводимый объем реагентов для гипоспреев.
/:cl:
```
