### PR TITLE
Tank space fix (#16492)

### DIFF
--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -135,7 +135,10 @@
 	var/new_z = (z != oldloc.z)
 	for(var/mob/living/tank_desant AS in tank_desants)
 		tank_desant.set_glide_size(root.glide_size)
-		tank_desant.forceMove(new_z ? loc : get_step(tank_desant, direction)) //For simplicity we just move desants to the middle of the tank on z change to avoid various issues
+		if(new_z)
+			tank_desant.abstract_move(loc) //todo: have some better code to actually preserve their location
+		else
+			tank_desant.forceMove(get_step(tank_desant, direction))
 		if(isxeno(tank_desant))
 			continue
 		if(move_dist > 1)


### PR DESCRIPTION
## `Основные изменения`
При смене з-левела людей на танке больше не должно отправлять в свободное падение.
## `Ченджлог`
```
:cl:
fix: Исправлена отправка людей на танке в свободное падение при смене з-уровня.
/:cl:
```
