### PR TITLE
Fixes admin Jump verb.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -618,7 +618,7 @@
 
 /datum/admins/proc/jump()
 	set category = "Admin"
-	set name = "Jump"
+	set name = "Jump To"
 
 	if(!check_rights(R_ADMIN))
 		return


### PR DESCRIPTION
## `Основные изменения`
Переименовал верб с `Jump` в `Jump To` чтобы при попытке использовать его в мобе, ты не прыгал.
## `Ченджлог`
```
:cl:
fix: Админский Jump теперь работает как нужно в живом теле.
/:cl:
```
