### PR TITLE
Adds corpsman satchel and backpack to cargo.

### DIFF
--- a/code/modules/reqs/clothing.dm
+++ b/code/modules/reqs/clothing.dm
@@ -27,6 +27,16 @@
 	contains = list(/obj/item/storage/backpack/marine/tech)
 	cost = 50
 
+/datum/supply_packs/clothing/corpsman_satchel
+	name = "TGMC corpsman satchel"
+	contains = list(/obj/item/storage/backpack/marine/corpsman/satchel)
+	cost = 100
+
+/datum/supply_packs/clothing/corpsman_backpack
+	name = "TGMC corpsman backpack"
+	contains = list(/obj/item/storage/backpack/marine/corpsman)
+	cost = 150 // higher price because it has a better cell
+
 /datum/supply_packs/clothing/officer_outfits
 	name = "officer outfits"
 	contains = list(

--- a/code/modules/reqs/clothing.dm
+++ b/code/modules/reqs/clothing.dm
@@ -30,12 +30,12 @@
 /datum/supply_packs/clothing/corpsman_satchel
 	name = "TGMC corpsman satchel"
 	contains = list(/obj/item/storage/backpack/marine/corpsman/satchel)
-	cost = 100
+	cost = 75
 
 /datum/supply_packs/clothing/corpsman_backpack
 	name = "TGMC corpsman backpack"
 	contains = list(/obj/item/storage/backpack/marine/corpsman)
-	cost = 150 // higher price because it has a better cell
+	cost = 125 // higher price because it has a better cell
 
 /datum/supply_packs/clothing/officer_outfits
 	name = "officer outfits"


### PR DESCRIPTION
## `Основные изменения`
В карго добавлены сумка и рюкзак корпсманов, за 75 и 125 поинтов, рюкзак дороже так как в нём лучше батарея.
## `Как это улучшит игру`
Теперь будет возможность приобрести рюкзак для дефиба, если проебал его.
## `Ченджлог`
```
:cl:
add: Добавил сумку и рюкзак корпсманов в карго.
/:cl:
```
