### PR TITLE
Acid well now doesn't spread acid smoke on destruction if it's empty.

### DIFF
--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -43,9 +43,9 @@
 		if(A)
 			to_chat(creator, span_xenoannounce("You sense your acid well at [A.name] has been destroyed!") )
 
-	if(damage_amount || damage_flag) //Spawn the gas only if we actually get destroyed by damage
+	if((damage_amount || damage_flag) && charges > 0) //Spawn the gas only if we actually get destroyed by damage
 		var/datum/effect_system/smoke_spread/xeno/acid/A = new(get_turf(src))
-		A.set_up(clamp(CEILING(charges*0.5, 1),0,3),src) //smoke scales with charges
+		A.set_up(clamp(CEILING(charges * 0.5, 1),0,3),src) //smoke scales with charges
 		A.start()
 	return ..()
 
@@ -61,7 +61,7 @@
 
 /obj/structure/xeno/acidwell/update_icon()
 	. = ..()
-	set_light(charges , charges / 2, LIGHT_COLOR_GREEN)
+	set_light(charges, charges * 0.5, LIGHT_COLOR_GREEN)
 
 /obj/structure/xeno/acidwell/update_overlays()
 	. = ..()


### PR DESCRIPTION
## `Основные изменения`
Если у колодца закончились заряды, то при уничтожении он не выпустит дыма.
## `Как это улучшит игру`
Выглядит логичным что пустой колодец, не выпускает кислоту при уничтожении.
## `Ченджлог`
```
:cl:
fix: Кислотный колодец теперь не выпускает кислоту при уничтожении если его заряды меньше 1.
/:cl:
```
