### PR TITLE
Reverts defiler's tentacle nerf.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -597,7 +597,7 @@
 	target.throw_at(get_step(owner, owner.dir), TENTACLE_ABILITY_RANGE, 1, owner, FALSE)
 	if(isliving(target))
 		var/mob/living/loser = target
-		loser.ImmobilizeNoChain(1 SECONDS) //RuTGMC Edit
+		loser.apply_effect(2 SECONDS, WEAKEN)
 		loser.adjust_stagger(5 SECONDS)
 
 ///signal handler to delete tetacle after we are done draggging owner along


### PR DESCRIPTION
## `Основные изменения`
Тентакля дефайлера теперь снова ложит на лопатки на 2 секунды.
## `Как это улучшит игру`
Понимаю что с этой абилкой дефайлер становиться почти однокнопочным, но, на данный момент эта абилка может быть использована разве что слабенький аналог притягивания шрики, ренжа нету, стана нету, зачем вообще такая абилка нужна.
## `Ченджлог`
```
:cl:
balance: Тентакля дефайлера теперь станит на 2 секунды.
/:cl:
```
