### PR TITLE
Adds abomination icon to orbit menu.

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -219,6 +219,7 @@ GLOBAL_LIST_INIT(playable_icons, list(
 	"hellhound",
 	"transport_crew",
 	"assault_crew",
+	"predalien",
 ))
 
 GLOBAL_LIST_EMPTY(human_ethnicities_list)


### PR DESCRIPTION
## `Основные изменения`
Предалиен теперь отображается в орбит меню.
## `Как это улучшит игру`
Удобство
## `Ченджлог`
```
:cl:
qol: Предалиен теперь имеет иконку в орбит меню.
/:cl:
```
