### PR TITLE
Adds missing apc's to Talos. Also changes hangar cables to be under CAS.

### DIFF
--- a/_maps/map_files/Talos/TGS_Talos.dmm
+++ b/_maps/map_files/Talos/TGS_Talos.dmm
@@ -447,7 +447,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "amp" = (
 /turf/open/floor/mainship/metal,
 /area/mainship/shipboard/brig)
@@ -1253,7 +1253,7 @@
 	dir = 6
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "aCP" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -1713,7 +1713,7 @@
 	dir = 2
 	},
 /turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "aUU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -2495,7 +2495,7 @@
 /obj/structure/bed/bunkbed,
 /obj/effect/spawner/random/food_or_drink/wine,
 /turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "buA" = (
 /obj/machinery/vending/marineFood,
 /obj/structure/sign/semiotic/food_storage{
@@ -2515,7 +2515,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "bvd" = (
 /obj/structure/table/black,
 /obj/item/flashlight/lamp,
@@ -3658,7 +3658,7 @@
 "cau" = (
 /obj/vehicle/unmanned/droid/scout,
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "cbf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -3759,7 +3759,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "ced" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4479,7 +4479,7 @@
 	},
 /obj/structure/sink/bathroom,
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "cyB" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -4535,7 +4535,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "czT" = (
 /obj/structure/barricade/metal{
 	dir = 8
@@ -4596,7 +4596,7 @@
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "cCB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1/alt{
 	dir = 4
@@ -4812,7 +4812,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/metal/lino,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "cHS" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/drinks/milk,
@@ -5130,7 +5130,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "cRn" = (
 /obj/structure/bed/chair/sofa{
 	dir = 8
@@ -5288,6 +5288,8 @@
 /area/mainship/hallways/hangar)
 "cWj" = (
 /obj/structure/table/mainship,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship,
 /turf/open/floor/mainship/metal/full,
 /area/mainship/engineering/engineering_workshop)
 "cWk" = (
@@ -5997,7 +5999,7 @@
 "dqV" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "drd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6919,7 +6921,7 @@
 	pixel_x = -17
 	},
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "dUP" = (
 /obj/structure/ship_rail_gun,
 /obj/effect/turf_decal/warning_stripes/thin,
@@ -7986,7 +7988,7 @@
 	dir = 10
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "eAk" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -9015,7 +9017,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "fap" = (
 /obj/structure/closet/marine/bravo,
 /obj/machinery/camera/autoname,
@@ -9190,7 +9192,7 @@
 "fdM" = (
 /obj/effect/spawner/random/misc/plant,
 /turf/open/floor/mainship/metal/lino,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "feg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -9224,9 +9226,9 @@
 /turf/open/floor/wood,
 /area/mainship/squads/alpha)
 "ffh" = (
-/obj/machinery/power/apc/mainship,
+/obj/effect/soundplayer,
 /turf/closed/wall/mainship/talos,
-/area/mainship/hallways/hangar)
+/area/mainship/command/airoom)
 "ffi" = (
 /obj/structure/closet/secure_closet/guncabinet/mp_armory,
 /turf/open/floor/mainship/red/full,
@@ -9253,7 +9255,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "ffQ" = (
 /obj/effect/turf_decal/warning_stripes/cargo,
 /obj/machinery/camera/autoname,
@@ -9298,7 +9300,7 @@
 	},
 /obj/structure/bed/namaz,
 /turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "fhn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -9324,7 +9326,7 @@
 /obj/structure/rack,
 /obj/item/storage/bible/koran,
 /turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "fiM" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -10046,7 +10048,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "fEN" = (
 /obj/structure/sink/bathroom,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/alt,
@@ -10420,9 +10422,8 @@
 /turf/open/floor/mainship/metal/full,
 /area/mainship/engineering/engine_core)
 "fTn" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/turf/closed/wall/mainship/talos,
+/area/mainship/command/airoom)
 "fTt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/misc/structure/barrel,
@@ -10629,7 +10630,7 @@
 	},
 /obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "fZY" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -10998,7 +10999,7 @@
 /obj/structure/bed/namaz,
 /obj/structure/bed/namaz,
 /turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "gsU" = (
 /obj/machinery/door/poddoor/mainship/mech,
 /turf/open/floor/plating/plating_catwalk/dark,
@@ -11150,7 +11151,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating/mainship/reinforced,
+/turf/open/floor/plating/plating_catwalk/dark,
 /area/mainship/hallways/hangar)
 "gxt" = (
 /obj/structure/bed/chair/wood/wings{
@@ -11810,7 +11811,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "gRq" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -11830,7 +11831,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "gSL" = (
 /turf/open/floor/mainship/metal/full,
 /area/mainship/shipboard/ex_firing_range)
@@ -12274,7 +12275,7 @@
 	dir = 10
 	},
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "hkv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12471,16 +12472,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/mainship/metal,
 /area/mainship/squads/alpha)
-"hqI" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/metal{
-	dir = 4
-	},
-/turf/open/floor/mainship/metal,
-/area/mainship/hallways/bow_hallway)
 "hqR" = (
 /obj/machinery/air_alarm{
 	dir = 1
@@ -12588,7 +12579,7 @@
 "hwm" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "hwt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -13366,7 +13357,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "hXx" = (
 /turf/open/floor/plating/plating_catwalk/dark,
 /area/mainship/hallways/hangar)
@@ -14123,7 +14114,7 @@
 "iwJ" = (
 /obj/effect/turf_decal/siding/metal,
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "iwX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14379,7 +14370,7 @@
 /obj/machinery/door/poddoor/mainship/ai/exterior,
 /obj/machinery/door/firedoor,
 /turf/open/floor/mainship/stripesquare,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "iGk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/mainship/small{
@@ -14579,7 +14570,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "iKR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -14912,7 +14903,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "iTQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/adv,
@@ -14986,7 +14977,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "iWU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16715,7 +16706,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "kam" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 6
@@ -17188,7 +17179,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "kmC" = (
 /obj/machinery/computer/autodoc_console,
 /turf/open/floor/mainship/metal/white{
@@ -17841,7 +17832,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "kHm" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -17927,6 +17918,16 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/mainship/orange,
 /area/mainship/squads/bravo)
+"kJg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/shuttle_immune,
+/turf/open/floor/plating/plating_catwalk/dark,
+/area/mainship/hallways/hangar)
 "kJi" = (
 /obj/item/radio/intercom/general{
 	dir = 1;
@@ -18035,7 +18036,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/warning_stripes/fulltile,
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "kLk" = (
 /obj/effect/turf_decal/tile/metal/medical,
 /turf/open/floor/mainship/metal/white{
@@ -18461,7 +18462,7 @@
 	pixel_x = -17
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "kWS" = (
 /obj/structure/platform{
 	dir = 4
@@ -18685,7 +18686,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "ldn" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -18728,7 +18729,7 @@
 /obj/item/namaz,
 /obj/item/namaz,
 /turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "lfB" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -19099,15 +19100,6 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hull/upper_hull)
-"lql" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/mainship/reinforced,
-/area/mainship/hallways/hangar)
 "lqv" = (
 /obj/effect/turf_decal/siding/metal{
 	dir = 6
@@ -19531,7 +19523,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "lyk" = (
 /obj/structure/disposalpipe/junction/flipped,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -20321,7 +20313,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "lSZ" = (
 /obj/structure/closet/secure_closet/CMO,
 /turf/open/floor/wood,
@@ -20683,7 +20675,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/mainship/metal/lino,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "meZ" = (
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor/grass,
@@ -21744,7 +21736,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "mKx" = (
 /obj/effect/turf_decal/siding/metal{
 	dir = 8
@@ -22513,7 +22505,7 @@
 /obj/machinery/camera/autoname,
 /obj/effect/spawner/random/misc/plushie,
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "nfW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -22628,7 +22620,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "nks" = (
 /obj/machinery/door/airlock/mainship/generic/corporate{
 	dir = 2
@@ -22948,8 +22940,16 @@
 /area/mainship/command/cic)
 "nsu" = (
 /obj/structure/cable,
-/turf/open/floor/plating/mainship/reinforced,
-/area/mainship/hallways/hangar)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/mainship,
+/turf/open/floor/plating,
+/area/mainship/hull/starboard_hull)
 "nsQ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/blackgeneric/glass,
 /obj/machinery/door/firedoor{
@@ -23164,7 +23164,7 @@
 "nzK" = (
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "nzS" = (
 /obj/effect/turf_decal/siding/metal{
 	dir = 8
@@ -24023,7 +24023,7 @@
 "nXJ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/dark,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "nYl" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/metal/full,
@@ -24397,7 +24397,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "oky" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/yellow{
@@ -24635,7 +24635,7 @@
 "oqy" = (
 /obj/item/storage/bible/koran,
 /turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "orG" = (
 /obj/effect/turf_decal/warning_stripes/cargo/arrow,
 /turf/open/floor/plating,
@@ -24726,7 +24726,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "owr" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -24843,8 +24843,14 @@
 /turf/open/floor/plating,
 /area/mainship/medical/operating_room_two)
 "oAl" = (
-/turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/emerald{
+	dir = 8
+	},
+/area/mainship/hallways/starboard_umbilical)
 "oAA" = (
 /turf/open/floor/mainship/metal/white{
 	color = "#E2E0DC"
@@ -24855,6 +24861,7 @@
 /obj/item/tool/extinguisher,
 /obj/item/tool/extinguisher,
 /obj/item/tool/extinguisher,
+/obj/structure/cable,
 /turf/open/floor/mainship/metal/full,
 /area/mainship/engineering/engineering_workshop)
 "oAS" = (
@@ -25105,7 +25112,7 @@
 /obj/effect/ai_node,
 /obj/machinery/floor_warn_light/self_destruct,
 /turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "oIc" = (
 /obj/effect/turf_decal/siding/metal,
 /obj/machinery/camera/autoname{
@@ -26197,7 +26204,7 @@
 /area/mainship/hallways/bow_hallway)
 "pou" = (
 /turf/closed/wall/mainship/outer/talos,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "ppm" = (
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
@@ -26902,7 +26909,7 @@
 /obj/machinery/computer3/server/rack,
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "pIz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -27130,7 +27137,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "pOu" = (
 /turf/open/floor/prison/red{
 	dir = 1
@@ -27142,7 +27149,7 @@
 	},
 /obj/effect/landmark/start/job/shiptech,
 /turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "pOE" = (
 /obj/structure/sign/semiotic/security{
 	pixel_x = 8;
@@ -27945,7 +27952,7 @@
 /obj/effect/landmark/start/job/shiptech,
 /obj/structure/bed/bunkbed,
 /turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "qkx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28047,7 +28054,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "qoh" = (
 /turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
@@ -28092,7 +28099,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk/dark,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "qpB" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 5
@@ -28119,11 +28126,11 @@
 	},
 /obj/effect/landmark/start/job/shiptech,
 /turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "qpX" = (
 /obj/structure/bed/namaz,
 /turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "qqs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1/alt{
 	dir = 1
@@ -28352,7 +28359,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating/plating_catwalk/dark,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "qvh" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/metal,
@@ -28852,7 +28859,7 @@
 /area/mainship/command/telecomms)
 "qOp" = (
 /turf/open/floor/mainship/tcomms,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "qOI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/alt{
 	dir = 8
@@ -29412,8 +29419,8 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "rgL" = (
-/turf/closed/wall/mainship/talos,
-/area/mainship/living/port_emb)
+/turf/open/floor/plating,
+/area/mainship/command/airoom)
 "rgR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -30407,7 +30414,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk/dark,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "rKo" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/wood,
@@ -31759,7 +31766,7 @@
 "sCj" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "sCG" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
 /turf/open/floor/mainship/metal/full,
@@ -31832,7 +31839,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating/mainship/reinforced,
+/turf/open/floor/plating/plating_catwalk/dark,
 /area/mainship/hallways/hangar)
 "sEo" = (
 /obj/effect/turf_decal/warning_stripes/engineer,
@@ -33272,7 +33279,7 @@
 /obj/structure/table/fancywoodentable,
 /obj/machinery/computer/emails,
 /turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "tyG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -33404,7 +33411,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "tDO" = (
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
@@ -33640,7 +33647,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/metal,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "tOf" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/box/arrow,
@@ -33654,7 +33661,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/dark,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "tOQ" = (
 /obj/effect/turf_decal/warning_stripes/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -34048,7 +34055,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk/dark,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "uag" = (
 /obj/effect/turf_decal/siding/emblem/fifth{
 	dir = 8
@@ -34683,7 +34690,7 @@
 	},
 /obj/effect/turf_decal/warning_stripes/fulltile,
 /turf/open/floor/mainship/metal,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "usS" = (
 /obj/machinery/firealarm,
 /obj/effect/turf_decal/tile/metal/medical{
@@ -35005,7 +35012,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk/dark,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "uCC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35221,7 +35228,7 @@
 "uJJ" = (
 /obj/structure/closet/secure_closet/shiptech,
 /turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "uJP" = (
 /obj/structure/table/mainship,
 /obj/machinery/reagentgrinder,
@@ -35527,9 +35534,9 @@
 /turf/open/floor/mainship/metal,
 /area/mainship/hallways/hangar)
 "uUj" = (
-/obj/effect/soundplayer,
-/turf/closed/wall/mainship/talos,
-/area/mainship/living/port_emb)
+/obj/machinery/light/mainship/small,
+/turf/open/floor/plating,
+/area/mainship/command/airoom)
 "uUt" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -36910,7 +36917,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "vME" = (
 /obj/effect/turf_decal/tile/transparent/dark_blue/diagonal_centre,
 /obj/structure/bed/chair,
@@ -37444,7 +37451,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk/dark,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "wct" = (
 /obj/effect/turf_decal/warning_stripes/fulltile,
 /obj/machinery/door/firedoor{
@@ -38083,7 +38090,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk/dark,
-/area/mainship/living/port_emb)
+/area/mainship/living/bridgebunks)
 "wwV" = (
 /obj/structure/table/mainship,
 /obj/effect/turf_decal/tile/transparent/dark_blue/diagonal_centre,
@@ -39238,7 +39245,7 @@
 /area/mainship/squads/bravo)
 "xiO" = (
 /turf/open/floor/mainship/metal/full,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "xiY" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -40062,9 +40069,12 @@
 /turf/open/floor/plating,
 /area/mainship/hull/upper_hull)
 "xHt" = (
-/obj/effect/spawner/random/misc/plant,
-/turf/open/floor/wood,
-/area/mainship/living/port_emb)
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/mainship/hull/port_hull)
 "xHD" = (
 /obj/machinery/light/mainship/small{
 	dir = 1
@@ -40856,7 +40866,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/mainship/living/numbertwobunks)
+/area/mainship/command/airoom)
 "yfB" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/siding/metal{
@@ -41162,7 +41172,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating/mainship/reinforced,
+/turf/open/floor/plating/plating_catwalk/dark,
 /area/mainship/hallways/hangar)
 "ymi" = (
 /obj/structure/prop/mainship/missile_tube,
@@ -66688,7 +66698,7 @@ lLf
 pTt
 uEE
 uEE
-hqI
+uji
 jsn
 sWL
 wfA
@@ -67818,7 +67828,7 @@ xot
 xot
 iwc
 iwc
-ffh
+iwc
 iwc
 iwc
 snK
@@ -72073,11 +72083,11 @@ wHG
 xGL
 tdL
 xzH
-mgn
+ffh
 meW
 cHM
 fdM
-xOs
+fTn
 pgj
 pgj
 arl
@@ -72171,9 +72181,9 @@ azn
 xpo
 xpo
 uzd
-nsu
-nsu
-nsu
+xpo
+xpo
+xpo
 sEn
 xpo
 xpo
@@ -72330,11 +72340,11 @@ eIC
 trd
 paQ
 hgS
-xOs
-xOs
-xOs
-xOs
-xOs
+fTn
+fTn
+fTn
+fTn
+fTn
 pgj
 xTR
 pDb
@@ -72428,10 +72438,10 @@ azn
 xpo
 xpo
 uzd
-nsu
 xpo
 xpo
-lql
+xpo
+kJg
 xpo
 xpo
 cTs
@@ -72587,11 +72597,11 @@ qZg
 xGL
 qkI
 xzH
-xOs
-uNB
+fTn
+rgL
 fgN
 qpX
-xOs
+fTn
 pgj
 pgj
 owA
@@ -72685,9 +72695,9 @@ azn
 xpo
 xpo
 uzd
-nsu
-nsu
-nsu
+xpo
+xpo
+xpo
 sEn
 xpo
 xpo
@@ -72844,12 +72854,12 @@ dJv
 xGL
 tdL
 jrX
-xOs
+fTn
 oqy
 qpX
 gsB
-xOs
-xOs
+fTn
+fTn
 pou
 kUr
 kUr
@@ -73009,7 +73019,7 @@ sPp
 pQT
 qQY
 qwP
-qwP
+xHt
 tms
 wnT
 wnT
@@ -73102,10 +73112,10 @@ xGL
 tdL
 xzH
 aUz
-uNB
-uNB
-uNB
-uNB
+rgL
+rgL
+rgL
+rgL
 yfA
 pou
 xWl
@@ -73358,12 +73368,12 @@ ygD
 pzU
 ylu
 xzH
-xOs
+fTn
 fiv
 leO
-uNB
-uNB
-uNB
+rgL
+rgL
+rgL
 pou
 tJx
 tJx
@@ -73615,12 +73625,12 @@ fkO
 rBl
 tdL
 ykN
-xOs
-xOs
-xOs
-xOs
-xOs
-uNB
+fTn
+fTn
+fTn
+fTn
+fTn
+rgL
 pou
 pou
 pou
@@ -73872,23 +73882,23 @@ wKL
 wKL
 rQk
 srP
-xOs
-xOs
-xOs
-xOs
-xOs
-uNB
-uNB
-uNB
-uNB
+fTn
+fTn
+fTn
+fTn
+fTn
+rgL
+rgL
+rgL
+rgL
 yfA
-uNB
-uNB
-uNB
-uNB
+rgL
+rgL
+rgL
+rgL
 yfA
-uNB
-xOs
+rgL
+fTn
 xGL
 tdL
 xzH
@@ -74129,23 +74139,23 @@ uEE
 sWL
 tdL
 xzH
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-uNB
-xOs
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+rgL
+fTn
 xIC
 tdL
 xzH
@@ -74386,23 +74396,23 @@ pkh
 xGL
 tdL
 xzH
-xOs
-xOs
+fTn
+fTn
 cRk
 iTx
 fah
 qOp
 lSW
-xOs
-xOs
+fTn
+fTn
 njM
 qOp
 nzK
 qOp
 pHQ
-xOs
-uNB
-xOs
+fTn
+rgL
+fTn
 xBv
 tdL
 xzH
@@ -74643,7 +74653,7 @@ qis
 xGL
 shs
 xzH
-xOs
+fTn
 cau
 xiO
 xiO
@@ -74657,9 +74667,9 @@ qOp
 qOp
 qOp
 qOp
-xOs
-svX
-xOs
+fTn
+uUj
+fTn
 wzA
 tdL
 xzH
@@ -74900,7 +74910,7 @@ qis
 cEa
 shs
 srP
-xOs
+fTn
 cyo
 xiO
 gSm
@@ -74914,9 +74924,9 @@ dqV
 okm
 qOp
 pOe
-xOs
-uNB
-xOs
+fTn
+rgL
+fTn
 xlL
 tdL
 xzH
@@ -75157,7 +75167,7 @@ qis
 xGL
 yem
 xzH
-xOs
+fTn
 czD
 xiO
 hkt
@@ -75171,9 +75181,9 @@ qOp
 qOp
 qOp
 qOp
-xOs
-uNB
-xOs
+fTn
+rgL
+fTn
 trd
 hwh
 hgS
@@ -75414,23 +75424,23 @@ qis
 wzA
 shs
 ykN
-xOs
+fTn
 nfN
 xiO
 xiO
 xiO
 kHk
 xiO
-xOs
-xOs
+fTn
+fTn
 njM
 qOp
 nzK
 qOp
 pHQ
-xOs
-uNB
-xOs
+fTn
+rgL
+fTn
 xGL
 shs
 xzH
@@ -75671,23 +75681,23 @@ pkh
 trd
 paQ
 hgS
-xOs
+fTn
 cBS
 hwm
 hwm
 hwm
 lcC
 xiO
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-svX
-xOs
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+uUj
+fTn
 xGL
 shs
 xzH
@@ -75928,23 +75938,23 @@ jOf
 xGL
 asp
 srP
-xOs
-xOs
-xOs
+fTn
+fTn
+fTn
 iGh
-xOs
+fTn
 lyi
-xOs
-xOs
-xOs
+fTn
+fTn
+fTn
 yfA
-uNB
-uNB
+rgL
+rgL
 yfA
-uNB
-uNB
-uNB
-xOs
+rgL
+rgL
+rgL
+fTn
 lTC
 shs
 xzH
@@ -76185,23 +76195,23 @@ rgR
 vYQ
 wTG
 xzH
-mgn
-xOs
+ffh
+fTn
 dUj
 xiO
 iKN
 iVK
 buL
-mgn
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
-xOs
+ffh
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
+fTn
 sCj
-mgn
+ffh
 xGL
 shs
 xzH
@@ -77117,7 +77127,7 @@ ceH
 omb
 rsW
 omb
-omb
+oAl
 omb
 omb
 omb
@@ -77720,10 +77730,10 @@ uZf
 uZf
 uZf
 uZf
-rgL
-rgL
-rgL
-rgL
+uZf
+uZf
+uZf
+uZf
 xMw
 xMw
 hQI
@@ -77979,8 +77989,8 @@ sxt
 uZf
 qkj
 vMx
-fTn
-rgL
+sxt
+uZf
 cBK
 xMw
 xfQ
@@ -78234,10 +78244,10 @@ ahQ
 rzM
 rAz
 uZf
-xHt
+rAz
 oHZ
 pOz
-rgL
+uZf
 iqD
 xfQ
 nGa
@@ -78492,9 +78502,9 @@ rzM
 rAe
 uZf
 uJJ
-oAl
+rzM
 tyv
-rgL
+uZf
 aiU
 vqY
 xwh
@@ -78748,10 +78758,10 @@ uZf
 xYG
 uZf
 uZf
-uUj
+rBQ
 kLj
-rgL
-rgL
+uZf
+uZf
 nFG
 mwI
 xwh
@@ -79008,7 +79018,7 @@ tNX
 cdY
 tDL
 ezt
-rgL
+uZf
 urr
 xfQ
 xfQ
@@ -79265,7 +79275,7 @@ uCf
 quT
 nXJ
 iwJ
-rgL
+uZf
 aiU
 srJ
 xwh
@@ -79522,7 +79532,7 @@ mKs
 alY
 owp
 aCJ
-rgL
+uZf
 nFG
 vqY
 xwh
@@ -79776,10 +79786,10 @@ uZf
 xYG
 uZf
 uZf
-uUj
+rBQ
 kLj
-rgL
-rgL
+uZf
+uZf
 rGF
 fAS
 xfQ
@@ -80034,9 +80044,9 @@ rzM
 sxt
 uZf
 uJJ
-oAl
+rzM
 tyv
-rgL
+uZf
 bTX
 xfQ
 xfQ
@@ -80290,10 +80300,10 @@ ahQ
 rzM
 rAz
 uZf
-xHt
+rAz
 oHZ
 qpN
-rgL
+uZf
 xfQ
 xMw
 rTw
@@ -80549,8 +80559,8 @@ rAe
 uZf
 buy
 gRg
-fTn
-rgL
+sxt
+uZf
 xfQ
 xfQ
 rem
@@ -87867,7 +87877,7 @@ jPy
 jPy
 jPy
 jPy
-pqW
+nsu
 upc
 sHE
 opF

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -761,3 +761,7 @@ GLOBAL_LIST(hub_radial_layer_list)
 
 /obj/structure/cable/multilayer/layer23
 	cable_layer = CABLE_LAYER_2 | CABLE_LAYER_3
+
+//Cable subtype for cases when you need to path it under cas
+/obj/structure/cable/shuttle_immune
+	flags_atom = SHUTTLE_IMMUNE


### PR DESCRIPTION
## `Основные изменения`
Добавил отсутствующие, удалил лишние апц на Талосе.

Провода в ангаре теперь под касом. Провод именно под касом имеет флаг игнора шаттлов, поэтому ему норм.
![image](https://github.com/user-attachments/assets/21908e08-a211-451d-9aec-73c6d2a1bea5)
