### PR TITLE
Фикс рантайма медсканнера

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -213,7 +213,6 @@ REAGENT SCANNER
 		data["stomach_chemicals_lists"] = stomach_chemicals_lists
 	else
 		data["has_stomach_chemicals"] = 0
-		data["has_unknown_chemicals"] = FALSE
 		data["stomach_chemicals_lists"] = NONE
 
 	data["species"] = patient.species.species_flags & ROBOTIC_LIMBS ? "robot" : "human"

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -194,22 +194,27 @@ REAGENT SCANNER
 	data["chemicals_lists"] = chemicals_lists
 
 	var/datum/internal_organ/stomach/belly = patient.get_organ_slot(ORGAN_SLOT_STOMACH) // should it be this way?
-	data["has_stomach_chemicals"] = length(belly.reagents.reagent_list)
-	var/list/stomach_chemicals_lists = list()
-	for(var/datum/reagent/reagent AS in belly.reagents.reagent_list)
-		if(!reagent.scannable)
-			data["has_unknown_chemicals"] = TRUE
-			continue
-		var/reagent_overdosed = FALSE
-		if(reagent.overdose_threshold && reagent.volume > reagent.overdose_threshold)
-			reagent_overdosed = TRUE
-		stomach_chemicals_lists["[reagent.name]"] = list(
-			"name" = reagent.name,
-			"amount" = round(reagent.volume, 0.1),
-			"od" = reagent_overdosed,
-			"dangerous" = reagent_overdosed || istype(reagent, /datum/reagent/toxin)
-		)
-	data["stomach_chemicals_lists"] = stomach_chemicals_lists
+	if(belly)
+		data["has_stomach_chemicals"] = length(belly.reagents.reagent_list)
+		var/list/stomach_chemicals_lists = list()
+		for(var/datum/reagent/reagent AS in belly.reagents.reagent_list)
+			if(!reagent.scannable)
+				data["has_unknown_chemicals"] = TRUE
+				continue
+			var/reagent_overdosed = FALSE
+			if(reagent.overdose_threshold && reagent.volume > reagent.overdose_threshold)
+				reagent_overdosed = TRUE
+			stomach_chemicals_lists["[reagent.name]"] = list(
+				"name" = reagent.name,
+				"amount" = round(reagent.volume, 0.1),
+				"od" = reagent_overdosed,
+				"dangerous" = reagent_overdosed || istype(reagent, /datum/reagent/toxin)
+			)
+		data["stomach_chemicals_lists"] = stomach_chemicals_lists
+	else
+		data["has_stomach_chemicals"] = 0
+		data["has_unknown_chemicals"] = FALSE
+		data["stomach_chemicals_lists"] = NONE
 
 	data["species"] = patient.species.species_flags & ROBOTIC_LIMBS ? "robot" : "human"
 


### PR DESCRIPTION
Фикс рантайма при использовании медсканнера на робота.

```
RUNTIME: runtime error: Cannot read null.reagents
 - proc name: ui static data (/obj/item/healthanalyzer/ui_static_data)
 -   source file: code/game/objects/items/scanners.dm,197
 -   usr: Pepa (/mob/living/carbon/human/species/synthetic)
 -   src: the HF2 Medical Gloves (/obj/item/healthanalyzer/gloves)
 -   usr.loc: the cave (136,72,2) (/turf/open/floor/plating/ground/mars/random/cave)
 -   src.loc: Pepa (/mob/living/carbon/human/species/synthetic)
 -   call stack:
 - the HF2 Medical Gloves (/obj/item/healthanalyzer/gloves): ui static data(Pepa (/mob/living/carbon/human/species/synthetic))
 - /datum/tgui (/datum/tgui): get payload(null, 1, 1)
 - /datum/tgui (/datum/tgui): open()
 - the HF2 Medical Gloves (/obj/item/healthanalyzer/gloves): ui interact(Pepa (/mob/living/carbon/human/species/synthetic), /datum/tgui (/datum/tgui))
 - the HF2 Medical Gloves (/obj/item/healthanalyzer/gloves): analyze vitals(Toaster (/mob/living/carbon/human/species/robot), Pepa (/mob/living/carbon/human/species/synthetic), null)
 - the HF2 Medical Gloves (/obj/item/healthanalyzer/gloves): on unarmed attack(Pepa (/mob/living/carbon/human/species/synthetic), Toaster (/mob/living/carbon/human/species/robot))
 - Pepa (/mob/living/carbon/human/species/synthetic):  SendSignal("human_melee_unarmed_attack", /list (/list))
 - Pepa (/mob/living/carbon/human/species/synthetic): UnarmedAttack(Toaster (/mob/living/carbon/human/species/robot), 1, /list (/list))
 - Pepa (/mob/living/carbon/human/species/synthetic): ClickOn(Toaster (/mob/living/carbon/human/species/robot), the cave (137,72,2) (/turf/open/floor/plating/ground/mars/random/cave), "icon-x=12;icon-y=16;vis-x=17;v...")
 - Toaster (/mob/living/carbon/human/species/robot): Click(the cave (137,72,2) (/turf/open/floor/plating/ground/mars/random/cave), "mapwindow.map", "icon-x=12;icon-y=16;vis-x=17;v...")
```