### PR TITLE
Фикс рантайма remove_images_from_clients

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -90,8 +90,8 @@
 	remove_from?.images -= image
 
 /proc/remove_images_from_clients(image/I, list/show_to)
-	for(var/client/C AS in show_to)
-		C?.images -= I
+	for(var/client/C in show_to)
+		remove_image_from_client(I, C)
 
 
 /proc/flick_overlay(image/I, list/show_to, duration)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -91,7 +91,7 @@
 
 /proc/remove_images_from_clients(image/I, list/show_to)
 	for(var/client/C AS in show_to)
-		C.images -= I
+		C?.images -= I
 
 
 /proc/flick_overlay(image/I, list/show_to, duration)


### PR DESCRIPTION
```
RUNTIME: runtime error: Cannot read null.images
 - proc name: remove images from clients (/proc/remove_images_from_clients)
 -   source file: code/__HELPERS/game.dm,94
 -   usr: Mature Hunter (If) (/mob/living/carbon/xenomorph/hunter)
 -   src: null
 -   usr.loc: the cave (181,73,2) (/turf/open/floor/plating/ground/mars/random/cave)
 -   call stack:
 - remove images from clients(, /list (/list))
 - /datum/callback (/datum/callback): Invoke()
 - world: PushUsr(Mature Hunter (If) (/mob/living/carbon/xenomorph/hunter), /datum/callback (/datum/callback))
 - /datum/callback (/datum/callback): InvokeAsync()
 - Timer (/datum/controller/subsystem/timer): fire(0)
 - Timer (/datum/controller/subsystem/timer): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```