### PR TITLE
Фикс рантайма интегрированного медсканера

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -198,6 +198,9 @@
 	if(!force)
 		return FALSE
 
+	if(!M)
+		return FALSE
+
 	. = M.attacked_by(src, user)
 	if(. && hitsound)
 		playsound(loc, hitsound, 25, TRUE)
@@ -333,6 +336,9 @@
 		return FALSE
 
 	if(!force)
+		return FALSE	
+
+	if(!M)
 		return FALSE
 
 	. = M.attacked_by_alternate(src, user)


### PR DESCRIPTION
```
RUNTIME: runtime error: Cannot read null.name
 - proc name: ui static data (/obj/item/healthanalyzer/ui_static_data)
 -   source file: code/game/objects/items/scanners.dm,163
 -   usr: Diane \'Horny\' Belror (/mob/living/carbon/human)
 -   src: the HF2 integrated health anal... (/obj/item/healthanalyzer/integrated)
 -   usr.loc: the cave (153,68,2) (/turf/open/floor/plating/ground/mars/random/cave/rock)
 -   src.loc: null
 -   call stack:
 - the HF2 integrated health anal... (/obj/item/healthanalyzer/integrated): ui static data(Diane \'Horny\' Belror (/mob/living/carbon/human))
 - /datum/tgui (/datum/tgui): get payload(null, 1, 1)
 - /datum/tgui (/datum/tgui): send full update(null, null)
 - /datum/callback (/datum/callback): Invoke()
 - world: PushUsr(Diane \'Horny\' Belror (/mob/living/carbon/human), /datum/callback (/datum/callback))
 - /datum/callback (/datum/callback): InvokeAsync()
 - Timer (/datum/controller/subsystem/timer): fire(0)
 - Timer (/datum/controller/subsystem/timer): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```