### PR TITLE
Фикс рантайма детектора движения

### DIFF
--- a/code/game/objects/items/motion_detector.dm
+++ b/code/game/objects/items/motion_detector.dm
@@ -162,7 +162,7 @@
 
 ///Prepare the blip to be print on the operator screen
 /obj/item/attachable/motiondetector/proc/prepare_blip(mob/target, status)
-	if(!operator.client)
+	if(!operator || !operator.client)
 		return
 	if(!target) //если мы вызываем метод без target то где то в вышестоящем коде ошибка, но всё же лучше чем ничего
 		return
@@ -172,7 +172,7 @@
 	var/list/actualview = getviewsize(operator.client.view)
 	var/viewX = actualview[1]
 	var/viewY = actualview[2]
-	var/turf/center_view = get_view_center(operator)
+	var/turf/center_view = get_view_center(operator) ? get_view_center(operator) : get_turf(src)
 	var/screen_pos_y = target.y - center_view.y + round(viewY * 0.5) + 1
 	var/dir
 	if(screen_pos_y < 1)

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -868,7 +868,7 @@
 	var/list/actualview = getviewsize(operator.client.view)
 	var/viewX = actualview[1]
 	var/viewY = actualview[2]
-	var/turf/center_view = get_view_center(operator)
+	var/turf/center_view = get_view_center(operator) ? get_view_center(operator) : get_turf(src)
 	var/screen_pos_y = target.y - center_view.y + round(viewY * 0.5) + 1
 	var/dir
 	if(screen_pos_y < 1)


### PR DESCRIPTION
```
RUNTIME: runtime error: Cannot read null.y
 - proc name: prepare blip (/obj/item/armor_module/module/motion_detector/proc/prepare_blip)
 -   source file: code/modules/clothing/modular_armor/attachments/modules.dm,872
 -   usr: Alex \'Goida\' Brown (/mob/living/carbon/human)
 -   src: Tactical sensor helmet module (/obj/item/armor_module/module/motion_detector)
 -   usr.loc: the autodoc medical system (/obj/machinery/autodoc)
 -   src.loc: the M10X pattern marine helmet (/obj/item/clothing/head/modular/m10x)
 -   call stack:
 - Tactical sensor helmet module (/obj/item/armor_module/module/motion_detector): prepare blip(Viktor Ushkin (/mob/living/carbon/human), "friendly")
 - Tactical sensor helmet module (/obj/item/armor_module/module/motion_detector): do scan()
 - /datum/callback (/datum/callback): Invoke()
 - world: PushUsr(Alex \'Goida\' Brown (/mob/living/carbon/human), /datum/callback (/datum/callback))
 - /datum/callback (/datum/callback): InvokeAsync()
 - Timer (/datum/controller/subsystem/timer): fire(1)
 - Timer (/datum/controller/subsystem/timer): ignite(1)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```