### PR TITLE
Фикс рантайма death() и droplimb()

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -47,8 +47,10 @@
 
 
 /mob/living/carbon/human/death(gibbing, deathmessage, silent, special_death_message)
+	if(!species)
+		return ..()
 	if(stat == DEAD)
-		species?.handle_death(src, gibbing)
+		species.handle_death(src, gibbing)
 		return ..()
 	if(species.death_message)
 		deathmessage = species.death_message

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -48,9 +48,7 @@
 
 /mob/living/carbon/human/death(gibbing, deathmessage, silent, special_death_message)
 	if(stat == DEAD)
-//RUTGMC EDIT
-		species.handle_death(src, gibbing)
-//RUTGMC EDIT
+		species?.handle_death(src, gibbing)
 		return ..()
 	if(species.death_message)
 		deathmessage = species.death_message

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -678,7 +678,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	else
 		set_limb_flags(LIMB_DESTROYED)
 
-	if(owner.species.species_flags & ROBOTIC_LIMBS)
+	if(owner?.species?.species_flags & ROBOTIC_LIMBS)
 		limb_status |= LIMB_ROBOT
 
 	for(var/i in implants)


### PR DESCRIPTION
```
[2024-09-07 09:52:21.938] RUNTIME: runtime error: Cannot read null.species
 - proc name: droplimb (/datum/limb/proc/droplimb)
 -   source file: code/modules/organs/limbs.dm,681
 -   usr: null
 -   src: r_hand (/datum/limb/hand/r_hand)
 -   call stack:
 - r_hand (/datum/limb/hand/r_hand): droplimb(null, 0, 1)
 - Jhon \'Frogy\' Richmand (/mob/living/carbon/human): gib()
 - Jhon \'Frogy\' Richmand (/mob/living/carbon/human): ex act(250, null)
 - /datum/automata_cell/explosion (/datum/automata_cell/explosion): update state(null)
 - Cellular Automata (/datum/controller/subsystem/cellauto): fire(0)
 - Cellular Automata (/datum/controller/subsystem/cellauto): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 
[2024-09-07 09:52:21.939] RUNTIME: runtime error: Cannot execute null.handle death().
 - proc name: death (/mob/living/carbon/human/death)
 -   source file: code/modules/mob/living/carbon/human/death.dm,52
 -   usr: null
 -   src: Jhon \'Frogy\' Richmand (/mob/living/carbon/human)
 -   src.loc: null
 -   call stack:
 - Jhon \'Frogy\' Richmand (/mob/living/carbon/human): death(1, null, null, null)
 - Jhon \'Frogy\' Richmand (/mob/living/carbon/human): gib()
 - Jhon \'Frogy\' Richmand (/mob/living/carbon/human): gib()
 - Jhon \'Frogy\' Richmand (/mob/living/carbon/human): ex act(250, null)
 - /datum/automata_cell/explosion (/datum/automata_cell/explosion): update state(null)
 - Cellular Automata (/datum/controller/subsystem/cellauto): fire(0)
 - Cellular Automata (/datum/controller/subsystem/cellauto): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```