### PR TITLE
Fixes crash latejoin spawns and cryopod dirs on bigbury and canterbury.

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -767,7 +767,9 @@
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "te" = (
-/obj/machinery/cryopod,
+/obj/machinery/cryopod{
+	dir = 8
+	},
 /turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
 "tP" = (

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -333,7 +333,9 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bn" = (
-/obj/machinery/cryopod,
+/obj/machinery/cryopod{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bo" = (

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -57,6 +57,9 @@
 	for(var/job_type in shuttle.spawns_by_job)
 		GLOB.spawns_by_job[job_type] = shuttle.spawns_by_job[job_type]
 
+	GLOB.start_squad_landmarks_list = null
+	GLOB.latejoin_squad_landmarks_list = null
+
 	GLOB.latejoin = shuttle.latejoins
 	GLOB.latejoin_cryo = shuttle.latejoins
 	GLOB.latejoin_gateway = shuttle.latejoins

--- a/code/datums/gamemodes/last_stand.dm
+++ b/code/datums/gamemodes/last_stand.dm
@@ -68,6 +68,7 @@
 		GLOB.latejoin_gateway -= loc
 
 	GLOB.start_squad_landmarks_list = null
+	GLOB.latejoin_squad_landmarks_list = null
 
 /datum/game_mode/last_stand/post_setup()
 	. = ..()


### PR DESCRIPTION
## `Основные изменения`
При догрузке режимы краша и ласт стэнда обнуляют точки спавна сквадов.

Криокапсулы на Бигбери и Кантербери теперь смотрят в правильные стороны.
## `Ченджлог`
```
:cl:
fix: Летйджоин спавны на краше теперь должны работать.
/:cl:
```
