### PR TITLE
Guns runtime fixes

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -457,6 +457,8 @@
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] || modifiers["ctrl"])
 		return
+	if(QDELETED(object))
+		return
 	set_target(get_turf_on_clickcatcher(object, living_user, params))
 	if(!current_target)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -817,6 +817,8 @@
 	var/mob/living/carbon/xenomorph/xeno = owner
 	if(!can_use_ability(object, TRUE, can_use_ability_flags))
 		return fail_activate()
+	if(QDELETED(object))
+		return
 	set_target(get_turf_on_clickcatcher(object, xeno, params))
 	if(!current_target)
 		return

--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -68,6 +68,8 @@
 		return
 	if(TIMER_COOLDOWN_CHECK(chassis, COOLDOWN_MECHA_EQUIPMENT(type)))
 		return
+	if(QDELETED(target))
+		return
 	TIMER_COOLDOWN_START(chassis, COOLDOWN_MECHA_EQUIPMENT(type), projectile_delay)
 
 	set_target(get_turf_on_clickcatcher(target, source, list2params(modifiers)))

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -65,6 +65,9 @@
 		return FALSE
 	. = ..()
 
+
+	if(QDELETED(target))
+		return
 	set_target(get_turf_on_clickcatcher(target, source, list2params(modifiers)))
 	if(!current_target)
 		return


### PR DESCRIPTION
Фикс
`[19:19:43] Runtime in code/__HELPERS/unsorted.dm, line 133: Cannot read null.x
 proc name: get angle with scatter (/proc/get_angle_with_scatter)
 usr: Ge4ok/(Denis Artillerist Gnatik)
 usr.loc: (Tank Interior (109, 12, 4))
 src: null
 call stack:
 get angle with scatter(the MT - Banteng (/obj/vehicle/sealed/armored/multitile), null, 0, 16, 16)
 the secondary cupola minigun (/obj/item/armored_weapon/secondary_weapon): fire()
 /datum/callback (/datum/callback): Invoke()
 world: PushUsr(Denis Artillerist Gnatik (/mob/living/carbon/human), /datum/callback (/datum/callback))
 /datum/callback (/datum/callback): Invoke()
 /datum/component/automatedfire... (/datum/component/automatedfire/autofire): process shot()
 Automated fire (/datum/controller/subsystem/automatedfire): fire(0)
 Automated fire (/datum/controller/subsystem/automatedfire): fire(0)
 Automated fire (/datum/controller/subsystem/automatedfire): ignite(0)
 Master (/datum/controller/master): RunQueue()
 Master (/datum/controller/master): Loop(2)
 Master (/datum/controller/master): StartProcessing(0)`