### PR TITLE
Adds additional check for grenade throw_at.

### DIFF
--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -119,11 +119,10 @@
 /obj/item/explosive/grenade/throw_at()
 	. = ..()
 	playsound(thrower, G_throw_sound, 25, 1, 6)
-	sleep(0.3 SECONDS)
-	playsound(loc, G_hit_sound, 20, 1, 9)
+	if(G_hit_sound)
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), loc, G_hit_sound, 20, 1, 9), 1 SECONDS)
 
 ////RAD GRENADE - TOTALLY RAD MAN
-
 /obj/item/explosive/grenade/rad
 	name = "\improper V-40 rad grenade"
 	desc = "Rad grenades release an extremely potent but short lived burst of radiation, debilitating organic life and frying electronics in a moderate radius. After the initial detonation, the radioactive effects linger for a time. Handle with extreme care."

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -119,7 +119,7 @@
 /obj/item/explosive/grenade/throw_at()
 	. = ..()
 	playsound(thrower, G_throw_sound, 25, 1, 6)
-	if(G_hit_sound)
+	if(!isnull(G_hit_sound))
 		sleep(0.3 SECONDS)
 		playsound(loc, G_hit_sound, 20, 1, 9)
 

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -120,7 +120,8 @@
 	. = ..()
 	playsound(thrower, G_throw_sound, 25, 1, 6)
 	if(G_hit_sound)
-		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), loc, G_hit_sound, 20, 1, 9), 1 SECONDS)
+		sleep(0.3 SECONDS)
+		playsound(loc, G_hit_sound, 20, 1, 9)
 
 ////RAD GRENADE - TOTALLY RAD MAN
 /obj/item/explosive/grenade/rad

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -519,11 +519,11 @@
 	light_system = MOVABLE_LIGHT
 	light_range = 6
 	light_color = LIGHT_COLOR_FLARE
+	G_hit_sound = null
+	G_throw_sound = null
 	var/fuel = 0
 	var/lower_fuel_limit = 450
 	var/upper_fuel_limit = 750
-	G_hit_sound = null
-	G_throw_sound = null
 
 /obj/item/explosive/grenade/flare/dissolvability(acid_strength)
 	return 2


### PR DESCRIPTION
## `Основные изменения`
Теперь слип вызываться будет только если у гранаты есть звук, который оно будет проигрывать потом.