### PR TITLE
Fixes tad breaking pipes for real this time.

### DIFF
--- a/_maps/shuttles/minidropship_big.dmm
+++ b/_maps/shuttles/minidropship_big.dmm
@@ -31,7 +31,7 @@
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -117,7 +117,7 @@
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -134,7 +134,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -167,7 +167,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/plating/plating_catwalk,

--- a/_maps/shuttles/minidropship_big.dmm
+++ b/_maps/shuttles/minidropship_big.dmm
@@ -31,7 +31,7 @@
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -117,7 +117,7 @@
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -134,7 +134,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -167,7 +167,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/plating/plating_catwalk,

--- a/_maps/shuttles/minidropship_factorio.dmm
+++ b/_maps/shuttles/minidropship_factorio.dmm
@@ -42,7 +42,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/mainship/mono,
@@ -80,7 +80,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/light{
@@ -139,7 +139,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/mainship/mono,
@@ -155,7 +155,7 @@
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -166,7 +166,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/light{

--- a/_maps/shuttles/minidropship_factorio.dmm
+++ b/_maps/shuttles/minidropship_factorio.dmm
@@ -42,7 +42,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/mainship/mono,
@@ -80,7 +80,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/light{
@@ -139,7 +139,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/mainship/mono,
@@ -155,7 +155,7 @@
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -166,7 +166,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/light{

--- a/_maps/shuttles/minidropship_food.dmm
+++ b/_maps/shuttles/minidropship_food.dmm
@@ -36,7 +36,7 @@
 /turf/closed/wall/mainship/outer/canterbury,
 /area/shuttle/minidropship)
 "l" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -57,7 +57,7 @@
 	pixel_y = -14
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -77,7 +77,7 @@
 	},
 /area/shuttle/minidropship)
 "s" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -106,7 +106,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "y" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -119,7 +119,7 @@
 	},
 /area/shuttle/minidropship)
 "z" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -194,7 +194,7 @@
 	},
 /area/shuttle/minidropship)
 "O" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -230,7 +230,7 @@
 	pixel_y = -14
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -240,7 +240,7 @@
 	},
 /area/shuttle/minidropship)
 "W" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,

--- a/_maps/shuttles/minidropship_food.dmm
+++ b/_maps/shuttles/minidropship_food.dmm
@@ -36,7 +36,7 @@
 /turf/closed/wall/mainship/outer/canterbury,
 /area/shuttle/minidropship)
 "l" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -57,7 +57,7 @@
 	pixel_y = -14
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -77,7 +77,7 @@
 	},
 /area/shuttle/minidropship)
 "s" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -106,7 +106,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "y" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -119,7 +119,7 @@
 	},
 /area/shuttle/minidropship)
 "z" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -194,7 +194,7 @@
 	},
 /area/shuttle/minidropship)
 "O" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -230,7 +230,7 @@
 	pixel_y = -14
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -240,7 +240,7 @@
 	},
 /area/shuttle/minidropship)
 "W" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,

--- a/_maps/shuttles/minidropship_mobile_bar.dmm
+++ b/_maps/shuttles/minidropship_mobile_bar.dmm
@@ -40,7 +40,7 @@
 	},
 /area/shuttle/minidropship)
 "m" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -60,7 +60,7 @@
 /turf/template_noop,
 /area/shuttle/minidropship)
 "o" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -95,7 +95,7 @@
 /area/shuttle/minidropship)
 "v" = (
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -164,7 +164,7 @@
 	pixel_y = -14
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -201,7 +201,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/minidropship)
 "G" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -231,7 +231,7 @@
 	},
 /area/shuttle/minidropship)
 "K" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -249,7 +249,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/minidropship)
 "O" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -296,7 +296,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/minidropship)
 "U" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,

--- a/_maps/shuttles/minidropship_mobile_bar.dmm
+++ b/_maps/shuttles/minidropship_mobile_bar.dmm
@@ -40,7 +40,7 @@
 	},
 /area/shuttle/minidropship)
 "m" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -60,7 +60,7 @@
 /turf/template_noop,
 /area/shuttle/minidropship)
 "o" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -95,7 +95,7 @@
 /area/shuttle/minidropship)
 "v" = (
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -164,7 +164,7 @@
 	pixel_y = -14
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -201,7 +201,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/minidropship)
 "G" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -231,7 +231,7 @@
 	},
 /area/shuttle/minidropship)
 "K" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -249,7 +249,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/minidropship)
 "O" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -296,7 +296,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/minidropship)
 "U" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,

--- a/_maps/shuttles/minidropship_standard.dmm
+++ b/_maps/shuttles/minidropship_standard.dmm
@@ -63,7 +63,7 @@
 /obj/structure/barricade/plasteel{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -87,7 +87,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/minidropship)
 "v" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -105,7 +105,7 @@
 /obj/structure/barricade/plasteel{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -127,7 +127,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -143,7 +143,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -175,7 +175,7 @@
 /obj/structure/barricade/plasteel{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/light{
@@ -186,7 +186,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "Q" = (
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -210,7 +210,7 @@
 /obj/structure/barricade/plasteel{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/light{

--- a/_maps/shuttles/minidropship_standard.dmm
+++ b/_maps/shuttles/minidropship_standard.dmm
@@ -63,7 +63,7 @@
 /obj/structure/barricade/plasteel{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -87,7 +87,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/minidropship)
 "v" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -105,7 +105,7 @@
 /obj/structure/barricade/plasteel{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -127,7 +127,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -143,7 +143,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
@@ -175,7 +175,7 @@
 /obj/structure/barricade/plasteel{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/light{
@@ -186,7 +186,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "Q" = (
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	dir = 2;
 	id = "minidropship_podlock"
 	},
@@ -210,7 +210,7 @@
 /obj/structure/barricade/plasteel{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/light{

--- a/_maps/shuttles/minidropship_umbilical.dmm
+++ b/_maps/shuttles/minidropship_umbilical.dmm
@@ -2,7 +2,7 @@
 "a" = (
 /obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/mainship/floor,
@@ -197,7 +197,7 @@
 /area/shuttle/minidropship)
 "U" = (
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open/shuttle{
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing{
 	id = "minidropship_podlock"
 	},
 /obj/structure/barricade/plasteel{

--- a/_maps/shuttles/minidropship_umbilical.dmm
+++ b/_maps/shuttles/minidropship_umbilical.dmm
@@ -2,7 +2,7 @@
 "a" = (
 /obj/structure/window/framed/mainship/canterbury/dropship/reinforced,
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /turf/open/floor/mainship/floor,
@@ -197,7 +197,7 @@
 /area/shuttle/minidropship)
 "U" = (
 /obj/machinery/door/poddoor/shutters/transit/nonsmoothing,
-/obj/machinery/door/poddoor/mainship/open{
+/obj/machinery/door/poddoor/mainship/open/shuttle{
 	id = "minidropship_podlock"
 	},
 /obj/structure/barricade/plasteel{

--- a/code/game/objects/machinery/doors/poddoor.dm
+++ b/code/game/objects/machinery/doors/poddoor.dm
@@ -212,8 +212,8 @@
 	name = "\improper Combat Information Center Blast Door"
 	id = "cic_lockdown"
 
-/obj/machinery/door/poddoor/mainship/open/shuttle
-	smoothing_groups = list(SMOOTH_GROUP_CANTERBURY)
+/obj/machinery/door/poddoor/mainship/open/nonsmoothing
+	smoothing_groups = null
 
 /obj/machinery/door/poddoor/mainship/hangar
 	name = "\improper Hangar Lockdown"

--- a/code/game/objects/machinery/doors/poddoor.dm
+++ b/code/game/objects/machinery/doors/poddoor.dm
@@ -186,7 +186,6 @@
 	layer = PODDOOR_OPEN_LAYER
 	icon_state = "pdoor0"
 
-
 /obj/machinery/door/poddoor/mainship/ai
 	name = "\improper AI Core Shutters"
 	icon_state = "pdoor0"
@@ -212,6 +211,9 @@
 /obj/machinery/door/poddoor/mainship/open/cic
 	name = "\improper Combat Information Center Blast Door"
 	id = "cic_lockdown"
+
+/obj/machinery/door/poddoor/mainship/open/shuttle
+	smoothing_groups = list(SMOOTH_GROUP_CANTERBURY)
 
 /obj/machinery/door/poddoor/mainship/hangar
 	name = "\improper Hangar Lockdown"

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -154,6 +154,7 @@
 	area.power_change()
 
 	QDEL_NULL(cell)
+	QDELL_NULL(cell_type)
 	QDEL_NULL(wires)
 	if(terminal)
 		disconnect_terminal()

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -154,7 +154,7 @@
 	area.power_change()
 
 	QDEL_NULL(cell)
-	QDELL_NULL(cell_type)
+	QDEL_NULL(cell_type)
 	QDEL_NULL(wires)
 	if(terminal)
 		disconnect_terminal()

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -154,7 +154,7 @@
 	area.power_change()
 
 	QDEL_NULL(cell)
-	QDEL_NULL(cell_type)
+	cell_type = null
 	QDEL_NULL(wires)
 	if(terminal)
 		disconnect_terminal()

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -206,15 +206,6 @@ All ShuttleMove procs go here
 		pipe_vision_img.loc = loc
 	var/missing_nodes = FALSE
 	for(var/i in 1 to device_type)
-		if(nodes[i])
-			var/obj/machinery/atmospherics/node = nodes[i]
-			var/connected = FALSE
-			for(var/dir in GLOB.cardinals)
-				if(node in get_step(src, dir))
-					connected = TRUE
-					break
-			if(connected)
-				nullifyNode(i)
 		if(!nodes[i])
 			missing_nodes = TRUE
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -204,23 +204,30 @@ All ShuttleMove procs go here
 	. = ..()
 	if(pipe_vision_img)
 		pipe_vision_img.loc = loc
+	var/missing_nodes = FALSE
 	for(var/i in 1 to device_type)
 		if(nodes[i])
 			var/obj/machinery/atmospherics/node = nodes[i]
 			var/connected = FALSE
-			for(var/D in GLOB.cardinals)
-				if(node in get_step(src, D))
+			for(var/dir in GLOB.cardinals)
+				if(node in get_step(src, dir))
 					connected = TRUE
 					break
 			if(connected)
 				nullifyNode(i)
+		if(!nodes[i])
+			missing_nodes = TRUE
 
-	atmosinit()
-	for(var/obj/machinery/atmospherics/A in pipeline_expansion())
-		A.atmosinit()
-		if(A.returnPipenet())
-			A.addMember(src)
-	build_network()
+	if(missing_nodes)
+		atmosinit()
+		for(var/obj/machinery/atmospherics/A in pipeline_expansion())
+			A.atmosinit()
+			if(A.returnPipenet())
+				A.addMember(src)
+		build_network()
+	else
+		// atmosinit() calls update_icon(), so we don't need to call it
+		update_icon()
 	covered_by_shuttle = FALSE
 
 /obj/machinery/atmospherics/pipe/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
@@ -230,8 +237,8 @@ All ShuttleMove procs go here
 
 /obj/machinery/power/terminal/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
-	var/turf/T = src.loc
-	if(level==1)
+	var/turf/T = loc
+	if(level == 1)
 		hide(T.intact_tile)
 
 /obj/machinery/atmospherics/components/unary/vent_pump/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)


### PR DESCRIPTION
## `Основные изменения`
Тад теперь не ломает трубы, ибо я удалил код отвечающий за это. Ибо он говно.
Также вернул проверку перед проком обновления труб, ибо после отлёта все 450 труб обновляются, и вызывают пролаг.

Бункерные двери на таде теперь не смузятся со стенами и прочим говном.
Исправил харддел у апц.
<!-- Опишите свой пулл реквест. -->

<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
fix: ТАд не ломает трубы после отлёта
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
