### PR TITLE
Fixes health analyzer SSD display (#14712)

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -294,12 +294,13 @@ REAGENT SCANNER
 			)
 			damaged_organs += list(current_organ)
 		data["damaged_organs"] = damaged_organs
-
+	var/ssd = null
 	if(patient.has_brain() && patient.stat != DEAD && ishuman(patient))
 		if(!patient.key)
-			data["ssd"] = "No soul detected." // they ghosted
+			ssd = "No soul detected." // they ghosted
 		else if(!patient.client)
-			data["ssd"] = "SSD detected." // SSD
+			ssd = "SSD detected." // SSD
+	data["ssd"] = ssd
 
 	return data
 


### PR DESCRIPTION
## `Основные изменения`
Если ты просканировал  ссд-шника, то в дальнейшем сканер будет отображать всех людей ССД.
## `Ченджлог`
```
:cl:
fix: Исправлено то что анализатор здоровья после сканирования ссд-шника, показывал всех как ссд.
/:cl:
```
