### PR TITLE
Ghost verb now doesn't need approval if mob is on centcomm z level.

### DIFF
--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -52,7 +52,7 @@
 		ghostize(TRUE)
 		return
 
-	if(tgui_alert(src, "Are you sure you want to ghost?\n(You are alive. If you ghost, you won't be able to return to your body. You can't change your mind so choose wisely!)", "Ghost", list("Yes", "No")) != "Yes")
+	if(!is_centcom_level(loc.z) && tgui_alert(src, "Are you sure you want to ghost?\n(You are alive. If you ghost, you won't be able to return to your body. You can't change your mind so choose wisely!)", "Ghost", list("Yes", "No")) != "Yes")
 		return
 
 	set_resting(TRUE)


### PR DESCRIPTION
## `Основные изменения`
Если моб на з-левеле Вальгаллы/Еорда то его не спрашивает "Уверены ли вы в том что хотите гостануться?"
## `Как это улучшит игру`
Удобство.
## `Ченджлог`
```
:cl:
qol: Команда Ghost больше не требует подтверждения если использовать её на Вальгалле/Еорде.
/:cl:
```
