### PR TITLE
Fixes sg153 magazines missing from cargo.

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -325,7 +325,7 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/weapon/gun/rifle/sg62 = list(CAT_SGSUP, "SG-62 Target Rifle", 25, "red"), //If a SG buys a SG-62, they'll have 15 points left, should be enough to buy some mags and or extra SR ammo.
 	/obj/item/ammo_magazine/rifle/sg62 = list(CAT_SGSUP, "SG-62 Target Rifle Magazine", 3, "orange2"),
 	/obj/item/ammo_magazine/packet/sg62 = list(CAT_SGSUP, "SG-62 smart target rifle ammo box", 5, "orange2"),
-	/obj/item/ammo_magazine/rifle/sg153 = list(CAT_SGSUP, "SG-153 Spotting Rifle Magazine", 2, "orange2"),
+	/obj/item/ammo_magazine/rifle/sg153 = list(CAT_SGSUP, "SG-153 Spotting Rifle Magazine", 1, "orange2"),
 	/obj/item/ammo_magazine/rifle/sg153/highimpact = list(CAT_SGSUP, "SG-153 Spotting Rifle High Impact Magazine", 2, "orange2"),
 	/obj/item/ammo_magazine/rifle/sg153/heavyrubber = list(CAT_SGSUP, "SG-153 Spotting Rifle Heavy Rubber Magazine", 2, "orange2"),
 	/obj/item/ammo_magazine/rifle/sg153/tungsten = list(CAT_SGSUP, "SG-153 Spotting Rifle Tungsten Magazine", 2, "orange2"),

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -325,7 +325,7 @@ GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(
 	/obj/item/weapon/gun/rifle/sg62 = list(CAT_SGSUP, "SG-62 Target Rifle", 25, "red"), //If a SG buys a SG-62, they'll have 15 points left, should be enough to buy some mags and or extra SR ammo.
 	/obj/item/ammo_magazine/rifle/sg62 = list(CAT_SGSUP, "SG-62 Target Rifle Magazine", 3, "orange2"),
 	/obj/item/ammo_magazine/packet/sg62 = list(CAT_SGSUP, "SG-62 smart target rifle ammo box", 5, "orange2"),
-	/obj/item/ammo_magazine/rifle/sg153 = list(CAT_SGSUP, "SG-153 Spotting Rifle Magazine", 1, "orange2"),
+	/obj/item/ammo_magazine/rifle/sg153 = list(CAT_SGSUP, "SG-153 Spotting Rifle Magazine", 2, "orange2"),
 	/obj/item/ammo_magazine/rifle/sg153/highimpact = list(CAT_SGSUP, "SG-153 Spotting Rifle High Impact Magazine", 2, "orange2"),
 	/obj/item/ammo_magazine/rifle/sg153/heavyrubber = list(CAT_SGSUP, "SG-153 Spotting Rifle Heavy Rubber Magazine", 2, "orange2"),
 	/obj/item/ammo_magazine/rifle/sg153/tungsten = list(CAT_SGSUP, "SG-153 Spotting Rifle Tungsten Magazine", 2, "orange2"),

--- a/code/modules/reqs/weapons.dm
+++ b/code/modules/reqs/weapons.dm
@@ -521,29 +521,35 @@
 	contains = list(/obj/item/ammo_magazine/rifle/sg153)
 	cost = 15
 
-/datum/supply_packs/weapons/sg153/highimpact
+/datum/supply_packs/weapons/sg153_ammo/highimpact
 	name = "SG-153 high impact spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/highimpact)
+	cost = 30
 
-/datum/supply_packs/weapons/sg153/heavyrubber
+/datum/supply_packs/weapons/sg153_ammo/heavyrubber
 	name = "SG-153 heavy rubber spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/heavyrubber)
+	cost = 30
 
-/datum/supply_packs/weapons/sg153/plasmaloss
+/datum/supply_packs/weapons/sg153_ammo/plasmaloss
 	name = "SG-153 tanglefoot spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/plasmaloss)
+	cost = 45
 
-/datum/supply_packs/weapons/sg153/tungsten
+/datum/supply_packs/weapons/sg153_ammo/tungsten
 	name = "SG-153 tungsten spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/tungsten)
+	cost = 30
 
-/datum/supply_packs/weapons/sg153/flak
+/datum/supply_packs/weapons/sg153_ammo/flak
 	name = "SG-153 flak spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/flak)
+	cost = 30
 
-/datum/supply_packs/weapons/sg153/incendiary
+/datum/supply_packs/weapons/sg153_ammo/incendiary
 	name = "SG-153 incendiary spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/incendiary)
+	cost = 45
 
 /datum/supply_packs/weapons/flamethrower
 	name = "FL-84 Flamethrower"

--- a/code/modules/reqs/weapons.dm
+++ b/code/modules/reqs/weapons.dm
@@ -524,32 +524,26 @@
 /datum/supply_packs/weapons/sg153_ammo/highimpact
 	name = "SG-153 high impact spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/highimpact)
-	cost = 30
 
 /datum/supply_packs/weapons/sg153_ammo/heavyrubber
 	name = "SG-153 heavy rubber spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/heavyrubber)
-	cost = 30
 
 /datum/supply_packs/weapons/sg153_ammo/plasmaloss
 	name = "SG-153 tanglefoot spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/plasmaloss)
-	cost = 45
 
 /datum/supply_packs/weapons/sg153_ammo/tungsten
 	name = "SG-153 tungsten spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/tungsten)
-	cost = 30
 
 /datum/supply_packs/weapons/sg153_ammo/flak
 	name = "SG-153 flak spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/flak)
-	cost = 30
 
 /datum/supply_packs/weapons/sg153_ammo/incendiary
 	name = "SG-153 incendiary spotting rifle ammo"
 	contains = list(/obj/item/ammo_magazine/rifle/sg153/incendiary)
-	cost = 45
 
 /datum/supply_packs/weapons/flamethrower
 	name = "FL-84 Flamethrower"


### PR DESCRIPTION
## `Основные изменения`
Магазины на СГ153 теперь снова в карго.
<!-- Опишите свой пулл реквест. -->

<!-- Ты должен быть способен объяснить ПОЧЕМУ это сделает нашу игру лучше, при этом твоё объяснение должно быть КАК МИНИМУМ логичным. -->

## `Ченджлог`

<!-- Данная форма позволяет игрокам наблюдать историю изменений прямо в игре и должна содержать тезисную информацию о том, как этот ПР повлияет на игрока, нежели его общее содержание. -->

<!-- Не удалять апострофы -->
```
:cl:
fix: Исправлено то что кастомных магазинов на СГ153 не было в карго.
/:cl:
```
<!-- Не удалять апострофы -->

<!-- Оба :cl:'а необходимы для того, чтобы вебхук работал и ваши изменения были видны в игре. Вы можете использовать сразу несколько одинаковых префиксов и спокойно удалять ненужные. Если вы ходите изменить никнейм, который будет показан с изменениями в игре - напишите его правее первого :cl:, в ином случае будет использован никнейм c GitHub. -->
