### PR TITLE
Probably fixes getting stuck after explosion throws.

### DIFF
--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -277,7 +277,7 @@ explosion resistance exactly as much as their health
 		target = locate(target.x + round(scatter_x, 1), target.y + round(scatter_y, 1), target.z) //Locate an adjacent turf.
 
 	//time for the explosion to destroy windows, walls, etc which might be in the way
-	throw_at(target, range, speed, null, TRUE)
+	throw_at(target, range, speed, null, TRUE, targetted_throw = FALSE)
 
 /mob/proc/explosion_throw(severity, direction)
 	if(anchored || !isturf(loc))
@@ -314,4 +314,4 @@ explosion resistance exactly as much as their health
 		target = locate(target.x + round(scatter_x, 1),target.y + round(scatter_y, 1), target.z) //Locate an adjacent turf.
 
 	//time for the explosion to destroy windows, walls, etc which might be in the way
-	throw_at(target, range, speed, null, spin)
+	throw_at(target, range, speed, null, spin, targetted_throw = FALSE)


### PR DESCRIPTION
## `Основные изменения`
Должно пофиксить то что после броска вызванного взрывом, моб мог застрять в состоянии недоброска.
## `Ченджлог`
```
:cl:
fix: Исправил застревание после отбрасывания взрывом.
/:cl:
```
