### PR TITLE
Decreases xeno respawn time from 5 to 3 minutes.

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -29,7 +29,7 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 	///The respawn time for marines
 	var/respawn_time = 15 MINUTES
 	//The respawn time for Xenomorphs
-	var/xenorespawn_time = 5 MINUTES
+	var/xenorespawn_time = 3 MINUTES
 	///How many points do you need to win in a point gamemode
 	var/win_points_needed = 0
 	///The points per faction, assoc list

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -21,7 +21,6 @@
 		/datum/job/terragov/squad/engineer = 5,
 		/datum/job/xenomorph = CRASH_LARVA_POINTS_NEEDED,
 	)
-	xenorespawn_time = 3 MINUTES
 	blacklist_ground_maps = list(MAP_BIG_RED, MAP_DELTA_STATION, MAP_PRISON_STATION, MAP_LV_624, MAP_WHISKEY_OUTPOST, MAP_OSCAR_OUTPOST, MAP_FORT_PHOBOS, MAP_LAST_STAND)
 
 	// Round end conditions


### PR DESCRIPTION
## `Основные изменения`
Таймер респавна ксеносов уменьшен с 5 до 3 минут.
## `Как это улучшит игру`
Таймер респавна маринам до 15 урезали, а про ксен забыли.
## `Ченджлог`
```
:cl:
balance: Респавн ксеносов уменьшен с 5 минут до 3-ёх.
/:cl:
```
