### PR TITLE
Fixes xray gun fire delay being inconsistent.

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -1035,7 +1035,7 @@
 /datum/lasrifle/energy_rifle_mode/xray
 	rounds_per_shot = 15
 	ammo_datum_type = /datum/ammo/energy/lasgun/marine/xray
-	fire_delay = 0.5 SECONDS
+	fire_delay = 0.4 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/laser3.ogg'
 	message_to_user = "You set the xray rifle's charge mode to standard fire."
 	fire_mode = GUN_FIREMODE_AUTOMATIC


### PR DESCRIPTION
## `Основные изменения`
У самой винтовки кд на выстрел стоит в 0.4, у режима стрельбы стояло 0.5, снизил режиму до 0.4
## `Ченджлог`
```
:cl:
fix: Исправил то что скорострельность искрэй винтовки падала после смены режима стрельбы назад на стандартный.
/:cl:
```
